### PR TITLE
nightly -> master: rating chart, manipulation analysis, and domain fixes

### DIFF
--- a/src/main/java/com/faforever/moderatorclient/api/FafUserCommunicationService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/FafUserCommunicationService.java
@@ -107,4 +107,19 @@ public class FafUserCommunicationService {
             throw t;
         }
     }
+
+    /**
+     * Best-effort POST that never publishes a failure event or throws.
+     * Returns true on success, false on any error (caller is responsible for logging).
+     */
+    @SneakyThrows
+    public boolean tryPost(String url, Object object) {
+        authorizedLatch.await();
+        try {
+            restTemplate.postForObject(url, object, String.class);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/faforever/moderatorclient/api/FafUserCommunicationService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/FafUserCommunicationService.java
@@ -112,12 +112,14 @@ public class FafUserCommunicationService {
      * Best-effort POST that never publishes a failure event or throws.
      * Returns true on success, false on any error (caller is responsible for logging).
      */
-    @SneakyThrows
     public boolean tryPost(String url, Object object) {
-        authorizedLatch.await();
         try {
+            authorizedLatch.await();
             restTemplate.postForObject(url, object, String.class);
             return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/faforever/moderatorclient/api/domain/BanService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/domain/BanService.java
@@ -36,7 +36,7 @@ public class BanService {
     public void patchBanInfo(@NotNull BanInfoFX banInfoFX) {
         BanInfo banInfo = banInfoMapper.map(banInfoFX);
         log.debug("Patching BanInfo of id: {}", banInfo.getId());
-        fafUser.post(REVOKE_ENDPOINT, RevokeRefreshTokenRequest.allClientsOf(banInfo.getPlayer().getId()));
+        tryRevokeTokens(banInfo.getPlayer().getId());
         banInfo.setAuthor(null);
         banInfo.setPlayer(null);
         fafApi.patch(ElideNavigator.of(BanInfo.class).id(banInfo.getId()), banInfo);
@@ -44,7 +44,7 @@ public class BanService {
 
     public String createBan(@NotNull BanInfoFX banInfoFX) {
         BanInfo banInfo = banInfoMapper.map(banInfoFX);
-        fafUser.post(REVOKE_ENDPOINT, RevokeRefreshTokenRequest.allClientsOf(banInfo.getPlayer().getId()));
+        tryRevokeTokens(banInfo.getPlayer().getId());
         return fafApi.post(ElideNavigator.of(BanInfo.class).collection(), banInfo).getId();
     }
 
@@ -76,8 +76,18 @@ public class BanService {
         ElideNavigatorOnId<BanInfo> navigator = ElideNavigator.of(BanInfo.class)
                 .id(banInfoUpdate.getId());
 
-        fafUser.post(REVOKE_ENDPOINT, RevokeRefreshTokenRequest.allClientsOf(banInfoUpdate.getPlayer().getId()));
+        tryRevokeTokens(banInfoUpdate.getPlayer().getId());
         fafApi.patch(navigator, banInfoUpdate);
+    }
+
+    private void tryRevokeTokens(String playerId) {
+        try {
+            fafUser.post(REVOKE_ENDPOINT, RevokeRefreshTokenRequest.allClientsOf(playerId));
+        } catch (Exception e) {
+            // Token revocation is best-effort; Cloudflare may block the request if no recent browser session
+            // exists for this IP. The ban/patch still proceeds — the player's tokens will expire naturally.
+            log.warn("Failed to revoke tokens for player {} (ban will still be applied): {}", playerId, e.getMessage());
+        }
     }
 
     public CompletableFuture<List<BanInfoFX>> getLatestBans() {

--- a/src/main/java/com/faforever/moderatorclient/api/domain/BanService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/domain/BanService.java
@@ -81,12 +81,11 @@ public class BanService {
     }
 
     private void tryRevokeTokens(String playerId) {
-        try {
-            fafUser.post(REVOKE_ENDPOINT, RevokeRefreshTokenRequest.allClientsOf(playerId));
-        } catch (Exception e) {
-            // Token revocation is best-effort; Cloudflare may block the request if no recent browser session
-            // exists for this IP. The ban/patch still proceeds — the player's tokens will expire naturally.
-            log.warn("Failed to revoke tokens for player {} (ban will still be applied): {}", playerId, e.getMessage());
+        // Best-effort: Cloudflare may block Java HTTP clients that haven't passed a browser challenge.
+        // The ban is always applied — tokens will expire naturally if revocation is blocked.
+        boolean revoked = fafUser.tryPost(REVOKE_ENDPOINT, RevokeRefreshTokenRequest.allClientsOf(playerId));
+        if (!revoked) {
+            log.warn("Failed to revoke tokens for player {} (ban will still be applied)", playerId);
         }
     }
 

--- a/src/main/java/com/faforever/moderatorclient/api/domain/UserService.java
+++ b/src/main/java/com/faforever/moderatorclient/api/domain/UserService.java
@@ -145,6 +145,7 @@ public class UserService {
                 .addInclude("game.mapVersion")
                 .addInclude("game.mapVersion.map")
                 .addInclude("ratingChanges")
+                .addInclude("ratingChanges.leaderboard")
                 .addSortingRule("scoreTime", false);
         if (featuredModFX != null) {
             navigator.setFilter(ElideNavigator.qBuilder().string("game.featuredMod.technicalName").eq(featuredModFX.getTechnicalName())

--- a/src/main/java/com/faforever/moderatorclient/config/TemplateAndReasonConfig.java
+++ b/src/main/java/com/faforever/moderatorclient/config/TemplateAndReasonConfig.java
@@ -13,10 +13,6 @@ public class TemplateAndReasonConfig {
     private String days;
     private String format;
 
-    @Setter
-    @Getter
     private List<TemplateAndReasonConfig> templates;
-    @Setter
-    @Getter
     private List<String> reasons;
 }

--- a/src/main/java/com/faforever/moderatorclient/mapstruct/GameMapper.java
+++ b/src/main/java/com/faforever/moderatorclient/mapstruct/GameMapper.java
@@ -3,13 +3,11 @@ package com.faforever.moderatorclient.mapstruct;
 import com.faforever.commons.api.dto.Game;
 import com.faforever.moderatorclient.ui.domain.GameFX;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring", uses = {JavaFXMapper.class, GamePlayerStatsMapper.class, PlayerMapper.class, FeaturedModMapper.class, MapVersionMapper.class})
 public abstract class GameMapper {
-    @Mapping(target = "reviews", ignore = true)
     public abstract GameFX map(Game dto);
 
     public abstract Game map(GameFX fxBean);

--- a/src/main/java/com/faforever/moderatorclient/ui/BansController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/BansController.java
@@ -95,6 +95,11 @@ public class BansController implements Controller<HBox> {
         playerRadioButton.setUserData((Supplier<List<BanInfoFX>>) () -> banService.getBanInfoByBannedPlayerNameContains(filter.getText()));
         banIdRadioButton.setUserData((Supplier<List<BanInfoFX>>) () -> Collections.singletonList(banService.getBanInfoById(filter.getText())));
         editBanButton.disableProperty().bind(banTableView.getSelectionModel().selectedItemProperty().isNull());
+        banTableView.setOnMouseClicked(event -> {
+            if (event.getClickCount() == 2 && banTableView.getSelectionModel().getSelectedItem() != null) {
+                editBan();
+            }
+        });
         InvalidationListener onlyActiveBansChangeListener = (observable) ->
                 filteredList.setPredicate(banInfoFX -> !onlyActiveCheckBox.isSelected() || banInfoFX.getBanStatus() == BanStatus.BANNED);
         onlyActiveCheckBox.selectedProperty().addListener(onlyActiveBansChangeListener);

--- a/src/main/java/com/faforever/moderatorclient/ui/UserDataController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/UserDataController.java
@@ -1,6 +1,8 @@
 package com.faforever.moderatorclient.ui;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -76,124 +78,94 @@ public class UserDataController {
     }
 
     // --- Typed classes for UserInfo ---
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class EmailEntry {
         private String email;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class UserAgentEntry {
         private String userAgent;
         private String addedOn;
     }
 
     // --- Typed classes for AccountHistory ---
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString
     public static class HistoryEntry {
         private String action;
         private String timestamp;
         private String description;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class LoginEntry {
         private String ip;
         private String addedOn;
     }
 
     // --- Typed classes for HardwareInfo ---
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class IpAddressEntry {
         private String ip;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class UuidEntry {
         private String uuid;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class DeviceIdEntry {
         private String deviceId;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class SerialNumberEntry {
         private String serialNumber;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class ProcessorIdEntry {
         private String processorId;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class CpuNameEntry {
         private String cpuName;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class BiosVersionEntry {
         private String biosVersion;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class ManufacturerEntry {
         private String manufacturer;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class HashEntry {
         private String hash;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class MemorySerialNumberEntry {
         private String memorySerialNumber;
         private String addedOn;
     }
 
-    @Getter
-    @Setter
-    @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class VolumeSerialNumberEntry {
         private String volumeSerialNumber;
         private String addedOn;

--- a/src/main/java/com/faforever/moderatorclient/ui/UserDataController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/UserDataController.java
@@ -91,7 +91,7 @@ public class UserDataController {
     }
 
     // --- Typed classes for AccountHistory ---
-    @Getter @Setter @ToString
+    @Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
     public static class HistoryEntry {
         private String action;
         private String timestamp;

--- a/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
@@ -70,6 +70,8 @@ import javafx.application.Platform;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import com.faforever.moderatorclient.ui.domain.UniqueIdFx;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -89,6 +91,10 @@ public class ViewHelper {
 
     private static final java.util.Map<String, List<UserNoteFX>> noteCache = new ConcurrentHashMap<>();
     private static final Set<String> noteLoadingInFlight = ConcurrentHashMap.newKeySet();
+
+    private static final DateTimeFormatter DT_DATETIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter DT_DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DT_UID = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     @Autowired
     public ViewHelper(SmurfManagementController smurfManagementController) {
@@ -395,34 +401,13 @@ public class ViewHelper {
         extractors.put(revocationAtColumn, BanInfoFX::getRevokeTime);
 
         TableColumn<BanInfoFX, OffsetDateTime> changeTimeColumn = new TableColumn<>("Created Time");
-        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        changeTimeColumn.setCellFactory(column -> new TableCell<BanInfoFX, OffsetDateTime>() {
-            @Override
-            protected void updateItem(OffsetDateTime item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    setText(item.format(dateFormatter));
-                }
-            }
-        });
+        changeTimeColumn.setCellFactory(offsetDateTimeCellFactory(DT_DATETIME));
         changeTimeColumn.setCellValueFactory(new PropertyValueFactory<>("createTime"));
         changeTimeColumn.setMinWidth(180);
         tableView.getColumns().add(changeTimeColumn);
 
         TableColumn<BanInfoFX, OffsetDateTime> updateTimeColumn = new TableColumn<>("Update Time");
-        updateTimeColumn.setCellFactory(column -> new TableCell<BanInfoFX, OffsetDateTime>() {
-            @Override
-            protected void updateItem(OffsetDateTime item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    setText(item.format(dateFormatter));
-                }
-            }
-        });
+        updateTimeColumn.setCellFactory(offsetDateTimeCellFactory(DT_DATETIME));
         updateTimeColumn.setCellValueFactory(new PropertyValueFactory<>("updateTime"));
         updateTimeColumn.setMinWidth(180);
         tableView.getColumns().add(updateTimeColumn);
@@ -442,19 +427,7 @@ public class ViewHelper {
         extractors.put(idColumn, NameRecordFX::getId);
 
         TableColumn<NameRecordFX, OffsetDateTime> changeTimeColumn = new TableColumn<>("Change Time");
-        changeTimeColumn.setCellFactory(column -> new TableCell<NameRecordFX, OffsetDateTime>() {
-            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-            @Override
-            protected void updateItem(OffsetDateTime item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    setText(item.format(dateFormatter));
-                }
-            }
-        });
+        changeTimeColumn.setCellFactory(offsetDateTimeCellFactory(DT_DATETIME));
         changeTimeColumn.setCellValueFactory(o -> o.getValue().changeTimeProperty());
         changeTimeColumn.setMinWidth(180);
         tableView.getColumns().add(changeTimeColumn);
@@ -702,13 +675,12 @@ public class ViewHelper {
         List<UserNoteFX> notes = noteCache.get(player.getId());
         if (notes != null && !notes.isEmpty()) {
             items.add(new SeparatorMenuItem());
-            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             notes.stream()
                     .sorted(Comparator.<UserNoteFX, OffsetDateTime>comparing(
                             n -> n.getCreateTime() != null ? n.getCreateTime() : OffsetDateTime.MIN)
                             .reversed())
                     .forEach(note -> {
-                        String date = note.getCreateTime() != null ? fmt.format(note.getCreateTime()) : "?";
+                        String date = note.getCreateTime() != null ? DT_DATE.format(note.getCreateTime()) : "?";
                         String author = note.getAuthor() != null ? note.getAuthor().getLogin() : "?";
                         String label = "[" + date + "] " + author + ": " + truncateNote(note.getNote(), 40);
                         MenuItem editItem = new MenuItem("Edit: " + label);
@@ -767,13 +739,12 @@ public class ViewHelper {
 
     private static String formatNotes(List<UserNoteFX> notes) {
         if (notes.isEmpty()) return "No notes";
-        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return notes.stream()
                 .sorted(Comparator.<UserNoteFX, OffsetDateTime>comparing(
                         n -> n.getCreateTime() != null ? n.getCreateTime() : OffsetDateTime.MIN)
                         .reversed())
                 .map(n -> {
-                    String date = n.getCreateTime() != null ? fmt.format(n.getCreateTime()) : "?";
+                    String date = n.getCreateTime() != null ? DT_DATE.format(n.getCreateTime()) : "?";
                     String author = n.getAuthor() != null && n.getAuthor().getLogin() != null
                             ? n.getAuthor().getLogin() : "?";
                     return "[" + date + "] " + author + ": " + n.getNote();
@@ -941,19 +912,7 @@ public class ViewHelper {
         extractors.put(emailColumn, PlayerFX::getEmail);
 
         TableColumn<PlayerFX, OffsetDateTime> createTimeColumn = new TableColumn<>("Registration Date");
-        createTimeColumn.setCellFactory(col -> new TableCell<>() {
-            private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-            @Override
-            protected void updateItem(OffsetDateTime item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    setText(formatter.format(item));
-                }
-            }
-        });
+        createTimeColumn.setCellFactory(offsetDateTimeCellFactory(DT_DATETIME));
 
         createTimeColumn.setCellValueFactory(o -> o.getValue().createTimeProperty());
         createTimeColumn.prefWidthProperty().bind(Bindings.createDoubleBinding(() ->
@@ -966,25 +925,13 @@ public class ViewHelper {
         lastLoginColumn.prefWidthProperty().bind(Bindings.createDoubleBinding(() ->
                 calculateMaxTextWidthPlayerFX(tableView.getItems(), PlayerFX::getLastLogin), tableView.getItems()));
 
-        lastLoginColumn.setCellFactory(col -> new TableCell<>() {
-            private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-            @Override
-            protected void updateItem(OffsetDateTime item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    setText(formatter.format(item));
-                }
-            }
-        });
+        lastLoginColumn.setCellFactory(offsetDateTimeCellFactory(DT_DATETIME));
         tableView.getColumns().add(lastLoginColumn);
 
         {
             {
                 if (showUidData) {
-                    DateTimeFormatter uidDateFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+                    DateTimeFormatter uidDateFmt = DT_UID;
 
                     // Shared sort order for in-cell UID lines; both columns use the same instance
                     // so line N in "UID Created" always matches line N in "UID Last Used".
@@ -1067,140 +1014,15 @@ public class ViewHelper {
                     extractors.put(userAgentColumn, PlayerFX::getUserAgent);
 
 
-                    TableColumn<PlayerFX, String> hashColumn = new TableColumn<>("Hash");
-                    hashColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getHash()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    hashColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    hashColumn.setMinWidth(40);
-                    tableView.getColumns().add(hashColumn);
-                    extractors.put(hashColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getHash()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> uuidColumn = new TableColumn<>("UUID");
-                    uuidColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getUuid()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    uuidColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    uuidColumn.setMinWidth(40);
-                    tableView.getColumns().add(uuidColumn);
-                    extractors.put(uuidColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getUuid()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> memorySerialColumn = new TableColumn<>("Memory S/N");
-                    memorySerialColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getMemorySerialNumber()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    memorySerialColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    memorySerialColumn.setMinWidth(40);
-                    tableView.getColumns().add(memorySerialColumn);
-                    extractors.put(memorySerialColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getMemorySerialNumber()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> deviceIdColumn = new TableColumn<>("Device ID");
-                    deviceIdColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getDeviceId()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    deviceIdColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    deviceIdColumn.setMinWidth(40);
-                    tableView.getColumns().add(deviceIdColumn);
-                    extractors.put(deviceIdColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getDeviceId()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> manufacturerColumn = new TableColumn<>("Manufacturer");
-                    manufacturerColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getManufacturer()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    manufacturerColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    manufacturerColumn.setMinWidth(40);
-                    tableView.getColumns().add(manufacturerColumn);
-                    extractors.put(manufacturerColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getManufacturer()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> cpuNameColumn = new TableColumn<>("CPU Name");
-                    cpuNameColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getName()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    cpuNameColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    cpuNameColumn.setMinWidth(40);
-                    tableView.getColumns().add(cpuNameColumn);
-                    extractors.put(cpuNameColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getName()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> processorIdColumn = new TableColumn<>("Processor Id");
-                    processorIdColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getProcessorId()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    processorIdColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    processorIdColumn.setMinWidth(40);
-                    tableView.getColumns().add(processorIdColumn);
-                    extractors.put(processorIdColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getProcessorId()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> serialColumn = new TableColumn<>("S/N");
-                    serialColumn.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getSerialNumber()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    serialColumn.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    serialColumn.setMinWidth(200);
-                    tableView.getColumns().add(serialColumn);
-                    extractors.put(serialColumn, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getSerialNumber()).collect(Collectors.toList());
-                    });
-
-                    TableColumn<PlayerFX, String> volumeSerialNumber = new TableColumn<>("Volume S/N");
-                    volumeSerialNumber.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getVolumeSerialNumber()).collect(Collectors.joining("\n"));
-                    }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
-                    volumeSerialNumber.setCellFactory(uidHighlightCellFactory(highlightTerm));
-                    volumeSerialNumber.setMinWidth(40);
-                    tableView.getColumns().add(volumeSerialNumber);
-                    extractors.put(volumeSerialNumber, playerFX -> {
-                        List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
-                        if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
-                        return list.stream().map(a -> a.getUniqueId().getVolumeSerialNumber()).collect(Collectors.toList());
-                    });
+                    addUidStringColumn(tableView, extractors, "Hash",        40,  a -> a.getUniqueId().getHash(),               uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "UUID",        40,  a -> a.getUniqueId().getUuid(),               uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "Memory S/N",  40,  a -> a.getUniqueId().getMemorySerialNumber(), uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "Device ID",   40,  a -> a.getUniqueId().getDeviceId(),           uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "Manufacturer",40,  a -> a.getUniqueId().getManufacturer(),       uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "CPU Name",    40,  a -> a.getUniqueId().getName(),               uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "Processor Id",40,  a -> a.getUniqueId().getProcessorId(),        uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "S/N",         200, a -> a.getUniqueId().getSerialNumber(),       uidSortOrder, highlightTerm);
+                    addUidStringColumn(tableView, extractors, "Volume S/N",  40,  a -> a.getUniqueId().getVolumeSerialNumber(), uidSortOrder, highlightTerm);
 
                     // Clicking "UID Created" or "UID Last Used" sorts lines within each cell.
                     // Both columns share uidSortOrder, so line N always stays paired across both.
@@ -1435,66 +1257,17 @@ public class ViewHelper {
         List<UserDataController.VolumeSerialNumberEntry> volumeList = new ArrayList<>();
 
         for (UniqueIdAssignmentFx item : playerFX.getUniqueIdAssignments()) {
-            if (item.getUniqueId().getUuid() != null && !item.getUniqueId().getUuid().isEmpty()) {
-                UserDataController.UuidEntry e = new UserDataController.UuidEntry();
-                e.setUuid(item.getUniqueId().getUuid());
-                e.setAddedOn(timestamp);
-                uuidList.add(e);
-            }
-            if (item.getUniqueId().getDeviceId() != null && !item.getUniqueId().getDeviceId().isEmpty()) {
-                UserDataController.DeviceIdEntry e = new UserDataController.DeviceIdEntry();
-                e.setDeviceId(item.getUniqueId().getDeviceId());
-                e.setAddedOn(timestamp);
-                deviceIdList.add(e);
-            }
-            if (item.getUniqueId().getSerialNumber() != null && !item.getUniqueId().getSerialNumber().isEmpty()) {
-                UserDataController.SerialNumberEntry e = new UserDataController.SerialNumberEntry();
-                e.setSerialNumber(item.getUniqueId().getSerialNumber());
-                e.setAddedOn(timestamp);
-                serialList.add(e);
-            }
-            if (item.getUniqueId().getProcessorId() != null && !item.getUniqueId().getProcessorId().isEmpty()) {
-                UserDataController.ProcessorIdEntry e = new UserDataController.ProcessorIdEntry();
-                e.setProcessorId(item.getUniqueId().getProcessorId());
-                e.setAddedOn(timestamp);
-                processorList.add(e);
-            }
-            if (item.getUniqueId().getName() != null && !item.getUniqueId().getName().isEmpty()) {
-                UserDataController.CpuNameEntry e = new UserDataController.CpuNameEntry();
-                e.setCpuName(item.getUniqueId().getName());
-                e.setAddedOn(timestamp);
-                cpuList.add(e);
-            }
-            if (item.getUniqueId().getSMBIOSBIOSVersion() != null && !item.getUniqueId().getSMBIOSBIOSVersion().isEmpty()) {
-                UserDataController.BiosVersionEntry e = new UserDataController.BiosVersionEntry();
-                e.setBiosVersion(item.getUniqueId().getSMBIOSBIOSVersion());
-                e.setAddedOn(timestamp);
-                biosList.add(e);
-            }
-            if (item.getUniqueId().getManufacturer() != null && !item.getUniqueId().getManufacturer().isEmpty()) {
-                UserDataController.ManufacturerEntry e = new UserDataController.ManufacturerEntry();
-                e.setManufacturer(item.getUniqueId().getManufacturer());
-                e.setAddedOn(timestamp);
-                manufacturerList.add(e);
-            }
-            if (item.getUniqueId().getHash() != null && !item.getUniqueId().getHash().isEmpty()) {
-                UserDataController.HashEntry e = new UserDataController.HashEntry();
-                e.setHash(item.getUniqueId().getHash());
-                e.setAddedOn(timestamp);
-                hashList.add(e);
-            }
-            if (item.getUniqueId().getMemorySerialNumber() != null && !item.getUniqueId().getMemorySerialNumber().isEmpty()) {
-                UserDataController.MemorySerialNumberEntry e = new UserDataController.MemorySerialNumberEntry();
-                e.setMemorySerialNumber(item.getUniqueId().getMemorySerialNumber());
-                e.setAddedOn(timestamp);
-                memoryList.add(e);
-            }
-            if (item.getUniqueId().getVolumeSerialNumber() != null && !item.getUniqueId().getVolumeSerialNumber().isEmpty()) {
-                UserDataController.VolumeSerialNumberEntry e = new UserDataController.VolumeSerialNumberEntry();
-                e.setVolumeSerialNumber(item.getUniqueId().getVolumeSerialNumber());
-                e.setAddedOn(timestamp);
-                volumeList.add(e);
-            }
+            UniqueIdFx uid = item.getUniqueId();
+            addIfNonEmpty(uid.getUuid(),               timestamp, uuidList,       UserDataController.UuidEntry::new);
+            addIfNonEmpty(uid.getDeviceId(),            timestamp, deviceIdList,   UserDataController.DeviceIdEntry::new);
+            addIfNonEmpty(uid.getSerialNumber(),        timestamp, serialList,     UserDataController.SerialNumberEntry::new);
+            addIfNonEmpty(uid.getProcessorId(),         timestamp, processorList,  UserDataController.ProcessorIdEntry::new);
+            addIfNonEmpty(uid.getName(),                timestamp, cpuList,        UserDataController.CpuNameEntry::new);
+            addIfNonEmpty(uid.getSMBIOSBIOSVersion(),   timestamp, biosList,       UserDataController.BiosVersionEntry::new);
+            addIfNonEmpty(uid.getManufacturer(),        timestamp, manufacturerList, UserDataController.ManufacturerEntry::new);
+            addIfNonEmpty(uid.getHash(),                timestamp, hashList,       UserDataController.HashEntry::new);
+            addIfNonEmpty(uid.getMemorySerialNumber(),  timestamp, memoryList,     UserDataController.MemorySerialNumberEntry::new);
+            addIfNonEmpty(uid.getVolumeSerialNumber(),  timestamp, volumeList,     UserDataController.VolumeSerialNumberEntry::new);
         }
 
         hardware.setUuidEntries(uuidList);
@@ -1545,6 +1318,47 @@ public class ViewHelper {
         }
 
         return false;
+    }
+
+    private static <T> Callback<TableColumn<T, OffsetDateTime>, TableCell<T, OffsetDateTime>> offsetDateTimeCellFactory(DateTimeFormatter fmt) {
+        return col -> new TableCell<>() {
+            @Override
+            protected void updateItem(OffsetDateTime item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(empty || item == null ? null : fmt.format(item));
+            }
+        };
+    }
+
+    private static TableColumn<PlayerFX, String> addUidStringColumn(
+            TableView<PlayerFX> tableView,
+            HashMap<TableColumn<PlayerFX, ?>, Function<PlayerFX, ?>> extractors,
+            String title,
+            double minWidth,
+            Function<UniqueIdAssignmentFx, String> fieldGetter,
+            SimpleObjectProperty<Comparator<UniqueIdAssignmentFx>> uidSortOrder,
+            @Nullable StringProperty highlightTerm) {
+        TableColumn<PlayerFX, String> col = new TableColumn<>(title);
+        col.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
+            List<UniqueIdAssignmentFx> list = new ArrayList<>(o.getValue().getUniqueIdAssignments());
+            if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
+            return list.stream().map(fieldGetter).collect(Collectors.joining("\n"));
+        }, o.getValue().getUniqueIdAssignments(), uidSortOrder));
+        col.setCellFactory(uidHighlightCellFactory(highlightTerm));
+        col.setMinWidth(minWidth);
+        tableView.getColumns().add(col);
+        extractors.put(col, playerFX -> {
+            List<UniqueIdAssignmentFx> list = new ArrayList<>(playerFX.getUniqueIdAssignments());
+            if (uidSortOrder.get() != null) list.sort(uidSortOrder.get());
+            return list.stream().map(fieldGetter).collect(Collectors.toList());
+        });
+        return col;
+    }
+
+    private static <E> void addIfNonEmpty(String value, String timestamp, List<E> list, BiFunction<String, String, E> creator) {
+        if (value != null && !value.isEmpty()) {
+            list.add(creator.apply(value, timestamp));
+        }
     }
 
     private static Callback<TableColumn<PlayerFX, String>, TableCell<PlayerFX, String>> uidHighlightCellFactory(
@@ -3139,20 +2953,7 @@ public class ViewHelper {
         extractors.put(lastModeratorColumn, reportFx -> reportFx.getLastModerator() == null ? null : reportFx.getLastModerator().getLogin());
 
         TableColumn<ModerationReportFX, OffsetDateTime> createTimeColumn = new TableColumn<>("Create time");
-
-        createTimeColumn.setCellFactory(col -> new TableCell<>() {
-            private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-            @Override
-            protected void updateItem(OffsetDateTime item, boolean empty) {
-                super.updateItem(item, empty);
-                if (empty || item == null) {
-                    setText(null);
-                } else {
-                    setText(formatter.format(item));
-                }
-            }
-        });
+        createTimeColumn.setCellFactory(offsetDateTimeCellFactory(DT_DATETIME));
 
         createTimeColumn.setCellValueFactory(param -> param.getValue().createTimeProperty());
         createTimeColumn.setId("createTimeColumn");

--- a/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/ViewHelper.java
@@ -187,6 +187,18 @@ public class ViewHelper {
         tableView.getColumns().add(urlColumn);
         extractors.put(urlColumn, AvatarFX::getUrl);
 
+        TableColumn<AvatarFX, Number> assignmentsColumn = new TableColumn<>("Assignments");
+        assignmentsColumn.setCellValueFactory(o -> Bindings.size(o.getValue().getAssignments()));
+        assignmentsColumn.setMinWidth(90);
+        tableView.getColumns().add(assignmentsColumn);
+
+        TableColumn<AvatarFX, Number> inUseColumn = new TableColumn<>("In use");
+        inUseColumn.setCellValueFactory(o -> Bindings.createIntegerBinding(
+                () -> (int) o.getValue().getAssignments().stream().filter(AvatarAssignmentFX::isSelected).count(),
+                o.getValue().getAssignments()));
+        inUseColumn.setMinWidth(60);
+        tableView.getColumns().add(inUseColumn);
+
         applyCopyContextMenus(tableView, extractors);
     }
 
@@ -975,8 +987,12 @@ public class ViewHelper {
                     DateTimeFormatter uidDateFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
                     // Shared sort order for in-cell UID lines; both columns use the same instance
-                    // so line N in "UID Created" always matches line N in "UID Last Used"
-                    var uidSortOrder = new SimpleObjectProperty<Comparator<UniqueIdAssignmentFx>>(null);
+                    // so line N in "UID Created" always matches line N in "UID Last Used".
+                    // Default: descending by updateTime (newest UID Last Used first).
+                    Comparator<UniqueIdAssignmentFx> defaultUidSort = Comparator.comparing(
+                            UniqueIdAssignmentFx::getUpdateTime,
+                            Comparator.nullsLast(Comparator.naturalOrder())).reversed();
+                    var uidSortOrder = new SimpleObjectProperty<Comparator<UniqueIdAssignmentFx>>(defaultUidSort);
 
                     TableColumn<PlayerFX, String> uidCreatedAt = new TableColumn<>("UID Created");
                     uidCreatedAt.setCellValueFactory(o -> Bindings.createStringBinding(() -> {
@@ -1204,7 +1220,7 @@ public class ViewHelper {
                             uidSortOrder.set(asc ? base : base.reversed());
                             return true;
                         }
-                        uidSortOrder.set(null);
+                        uidSortOrder.set(defaultUidSort);
                         if (tv.getComparator() != null) {
                             FXCollections.sort(tv.getItems(), tv.getComparator());
                         }

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/AvatarFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/AvatarFX.java
@@ -4,6 +4,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.image.Image;
@@ -19,7 +20,10 @@ public class AvatarFX extends AbstractEntityFX {
     public AvatarFX() {
         url = new SimpleStringProperty();
         tooltip = new SimpleStringProperty();
-        assignments = FXCollections.observableArrayList();
+        // Extractor fires list-change events when any assignment's selectedProperty toggles,
+        // so bindings that depend on this list (e.g. the "In use" column) stay up to date.
+        assignments = FXCollections.observableArrayList(
+                a -> new Observable[]{ a.selectedProperty() });
     }
 
     public String getUrl() {

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/AvatarFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/AvatarFX.java
@@ -47,7 +47,7 @@ public class AvatarFX extends AbstractEntityFX {
         return tooltip;
     }
 
-    public List<AvatarAssignmentFX> getAssignments() {
+    public ObservableList<AvatarAssignmentFX> getAssignments() {
         return assignments;
     }
 

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/FeaturedModFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/FeaturedModFX.java
@@ -2,8 +2,7 @@ package com.faforever.moderatorclient.ui.domain;
 
 import javafx.beans.property.*;
 
-public class FeaturedModFX {
-    private final StringProperty id;
+public class FeaturedModFX extends AbstractEntityFX {
     private final StringProperty description;
     private final StringProperty displayName;
     private final IntegerProperty order;
@@ -14,7 +13,6 @@ public class FeaturedModFX {
     private final BooleanProperty visible;
 
     public FeaturedModFX() {
-        this.id = new SimpleStringProperty();
         this.description = new SimpleStringProperty();
         this.displayName = new SimpleStringProperty();
         this.order = new SimpleIntegerProperty();
@@ -23,18 +21,6 @@ public class FeaturedModFX {
         this.bireusUrl = new SimpleStringProperty();
         this.technicalName = new SimpleStringProperty();
         this.visible = new SimpleBooleanProperty();
-    }
-
-    public String getId() {
-        return id.get();
-    }
-
-    public void setId(String id) {
-        this.id.set(id);
-    }
-
-    public StringProperty idProperty() {
-        return id;
     }
 
     public String getDescription() {

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GameFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GameFX.java
@@ -167,6 +167,10 @@ public class GameFX extends AbstractEntityFX {
     }
 
     public String getReplayUrl(String baseUrlFormat) {
-        return String.format(baseUrlFormat, id.get());
+        String idValue = id.get();
+        if (idValue == null) {
+            return null;
+        }
+        return String.format(baseUrlFormat, idValue);
     }
 }

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GameFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GameFX.java
@@ -1,6 +1,5 @@
 package com.faforever.moderatorclient.ui.domain;
 
-import com.faforever.commons.api.dto.GameReview;
 import com.faforever.commons.api.dto.Validity;
 import com.faforever.commons.api.dto.VictoryCondition;
 import javafx.beans.property.ObjectProperty;
@@ -20,7 +19,6 @@ public class GameFX extends AbstractEntityFX {
     private final ObjectProperty<OffsetDateTime> endTime;
     private final ObjectProperty<Validity> validity;
     private final ObjectProperty<VictoryCondition> victoryCondition;
-    private final ObservableList<GameReview> reviews;
     private final ObservableList<GamePlayerStatsFX> playerStats;
     private final ObjectProperty<PlayerFX> host;
     private final ObjectProperty<FeaturedModFX> featuredMod;
@@ -33,7 +31,6 @@ public class GameFX extends AbstractEntityFX {
         endTime = new SimpleObjectProperty<>();
         validity = new SimpleObjectProperty<>();
         victoryCondition = new SimpleObjectProperty<>();
-        reviews = FXCollections.observableArrayList();
         playerStats = FXCollections.observableArrayList();
         host = new SimpleObjectProperty<>();
         featuredMod = new SimpleObjectProperty<>();
@@ -112,10 +109,6 @@ public class GameFX extends AbstractEntityFX {
 
     public ObjectProperty<VictoryCondition> victoryConditionProperty() {
         return victoryCondition;
-    }
-
-    public ObservableList<GameReview> getReviews() {
-        return reviews;
     }
 
     public ObservableList<GamePlayerStatsFX> getPlayerStats() {

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GameFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GameFX.java
@@ -13,7 +13,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 public class GameFX extends AbstractEntityFX {
-    private final StringProperty id;
     private final StringProperty name;
     private final ObjectProperty<OffsetDateTime> startTime;
     private final ObjectProperty<OffsetDateTime> endTime;
@@ -25,7 +24,6 @@ public class GameFX extends AbstractEntityFX {
     private final ObjectProperty<MapVersionFX> mapVersion;
 
     public GameFX() {
-        id = new SimpleStringProperty();
         name = new SimpleStringProperty();
         startTime = new SimpleObjectProperty<>();
         endTime = new SimpleObjectProperty<>();
@@ -35,20 +33,6 @@ public class GameFX extends AbstractEntityFX {
         host = new SimpleObjectProperty<>();
         featuredMod = new SimpleObjectProperty<>();
         mapVersion = new SimpleObjectProperty<>();
-    }
-
-    @Override
-    public String getId() {
-        return id.get();
-    }
-
-    public void setId(String id) {
-        this.id.set(id);
-    }
-
-    @Override
-    public StringProperty idProperty() {
-        return id;
     }
 
     public String getName() {
@@ -160,7 +144,7 @@ public class GameFX extends AbstractEntityFX {
     }
 
     public String getReplayUrl(String baseUrlFormat) {
-        String idValue = id.get();
+        String idValue = getId();
         if (idValue == null) {
             return null;
         }

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GamePlayerStatsFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GamePlayerStatsFX.java
@@ -7,8 +7,6 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -16,7 +14,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 public class GamePlayerStatsFX extends AbstractEntityFX {
-    private final StringProperty id;
     private final BooleanProperty ai;
     private final ObjectProperty<Faction> faction;
     private final ObjectProperty<Byte> color;
@@ -32,7 +29,6 @@ public class GamePlayerStatsFX extends AbstractEntityFX {
     private final ObservableList<LeaderboardRatingJournalFX> leaderboardRatingJournals;
 
     public GamePlayerStatsFX() {
-        id = new SimpleStringProperty();
         ai = new SimpleBooleanProperty();
         faction = new SimpleObjectProperty<>();
         color = new SimpleObjectProperty<>();
@@ -106,20 +102,6 @@ public class GamePlayerStatsFX extends AbstractEntityFX {
 
     public ObjectProperty<Number> ratingChangeProperty() {
         return ratingChange;
-    }
-
-    @Override
-    public String getId() {
-        return id.get();
-    }
-
-    public void setId(String id) {
-        this.id.set(id);
-    }
-
-    @Override
-    public StringProperty idProperty() {
-        return id;
     }
 
     public boolean isAi() {

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GamePlayerStatsFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GamePlayerStatsFX.java
@@ -1,8 +1,8 @@
 package com.faforever.moderatorclient.ui.domain;
 
 import com.faforever.commons.api.dto.Faction;
-import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
+import javafx.collections.ListChangeListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -46,7 +46,7 @@ public class GamePlayerStatsFX extends AbstractEntityFX {
         ratingChange = new SimpleObjectProperty<>();
         beforeRating = new SimpleObjectProperty<>();
         afterRating = new SimpleObjectProperty<>();
-        leaderboardRatingJournals.addListener((InvalidationListener) observable -> leaderboardRatingJournals.stream().findFirst().ifPresent(ratingJournal -> {
+        leaderboardRatingJournals.addListener((ListChangeListener<LeaderboardRatingJournalFX>) change -> leaderboardRatingJournals.stream().findFirst().ifPresent(ratingJournal -> {
             beforeRating.unbind();
             afterRating.unbind();
             ratingChange.unbind();

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GamePlayerStatsFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GamePlayerStatsFX.java
@@ -84,24 +84,16 @@ public class GamePlayerStatsFX extends AbstractEntityFX {
         }));
     }
 
-    public int getBeforeRating() {
+    public Integer getBeforeRating() {
         return beforeRating.get();
-    }
-
-    public void setBeforeRating(int beforeRating) {
-        this.beforeRating.set(beforeRating);
     }
 
     public ObjectProperty<Integer> beforeRatingProperty() {
         return beforeRating;
     }
 
-    public int getAfterRating() {
+    public Integer getAfterRating() {
         return afterRating.get();
-    }
-
-    public void setAfterRating(int afterRating) {
-        this.afterRating.set(afterRating);
     }
 
     public ObjectProperty<Integer> afterRatingProperty() {
@@ -110,10 +102,6 @@ public class GamePlayerStatsFX extends AbstractEntityFX {
 
     public Number getRatingChange() {
         return ratingChange.get();
-    }
-
-    public void setRatingChange(int ratingChange) {
-        this.ratingChange.set(ratingChange);
     }
 
     public ObjectProperty<Number> ratingChangeProperty() {

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/GroupPermissionFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/GroupPermissionFX.java
@@ -6,12 +6,10 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import lombok.Value;
 
-@Value
 @EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 @ToString(callSuper = true, onlyExplicitlyIncluded = true)
-public class GroupPermissionFX extends AbstractEntityFX{
+public class GroupPermissionFX extends AbstractEntityFX {
     @ToString.Include
     StringProperty technicalName = new SimpleStringProperty();
     StringProperty nameKey = new SimpleStringProperty();

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/LeaderboardRatingJournalFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/LeaderboardRatingJournalFX.java
@@ -8,6 +8,8 @@ import javafx.beans.property.SimpleObjectProperty;
  */
 public class LeaderboardRatingJournalFX extends AbstractEntityFX {
 
+  // ObjectProperty<Double> rather than DoubleProperty: null is a meaningful sentinel used
+  // by GamePlayerStatsFX bindings to indicate that rating data is not yet available.
   private final ObjectProperty<Double> meanAfter = new SimpleObjectProperty<>();
   private final ObjectProperty<Double> deviationAfter = new SimpleObjectProperty<>();
   private final ObjectProperty<Double> meanBefore = new SimpleObjectProperty<>();

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/MapPoolAssignmentFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/MapPoolAssignmentFX.java
@@ -42,7 +42,7 @@ public class MapPoolAssignmentFX extends AbstractEntityFX {
     }
 
     public MapPoolAssignmentFX setWeight(Integer weight) {
-        this.weight.set(weight);
+        this.weight.set(weight != null ? weight : 0);
         return this;
     }
 

--- a/src/main/java/com/faforever/moderatorclient/ui/domain/MapPoolFX.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/domain/MapPoolFX.java
@@ -4,9 +4,6 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import java.util.List;
 
 public class MapPoolFX extends AbstractEntityFX {

--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/AvatarsController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/AvatarsController.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 @Slf4j
 @Component
@@ -114,37 +115,18 @@ public class AvatarsController implements Controller<SplitPane> {
         UrlImageViewTableCell.updateProgressLabel();
         avatarTableView.setPlaceholder(new ProgressIndicator());
 
-        Task<List<AvatarFX>> loadAvatarsTask = new Task<>() {
-            @Override
-            protected List<AvatarFX> call() {
-                int page = 1;
-                int pageSize = environmentProperties.getMaxResultPageSizeAvatars();
-                List<Avatar> currentPage;
-                List<AvatarFX> allAvatars = FXCollections.observableArrayList();
-
-                do {
-                    currentPage = avatarService.getAllAvatarsPage(page, pageSize);
-                    List<AvatarFX> fxPage = avatarMapper.map(currentPage);
-                    allAvatars.addAll(fxPage);
-                    page++;
-                } while (currentPage.size() == pageSize);
-
-                return allAvatars;
-            }
-        };
-
-        loadAvatarsTask.setOnSucceeded(event -> {
-            avatars.setAll(loadAvatarsTask.getValue());
-            avatarTableView.getSortOrder().clear();
-        });
-
-        loadAvatarsTask.setOnFailed(e -> {
-            Throwable t = loadAvatarsTask.getException();
-            log.error("Failed to load avatars", t);
-            ViewHelper.errorDialog("Error", "Failed to load avatars: " + t.getMessage());
-        });
-
-        new Thread(loadAvatarsTask, "LoadAvatarsThread").start();
+        runAvatarTask(() -> {
+            int page = 1;
+            int pageSize = environmentProperties.getMaxResultPageSizeAvatars();
+            List<Avatar> currentPage;
+            List<AvatarFX> allAvatars = FXCollections.observableArrayList();
+            do {
+                currentPage = avatarService.getAllAvatarsPage(page, pageSize);
+                allAvatars.addAll(avatarMapper.map(currentPage));
+                page++;
+            } while (currentPage.size() == pageSize);
+            return allAvatars;
+        }, "LoadAvatarsThread", "Failed to load avatars");
     }
 
     private void openAvatarDialog(AvatarFX avatarFX, boolean isNew) {
@@ -169,35 +151,19 @@ public class AvatarsController implements Controller<SplitPane> {
         boolean byTooltip = searchAvatarsByTooltipRadioButton.isSelected();
         boolean byUser = searchAvatarsByAssignedUserRadioButton.isSelected();
 
-        Task<List<AvatarFX>> searchTask = new Task<>() {
-            @Override
-            protected List<AvatarFX> call() {
-                List<Avatar> result;
-                if (byId) {
-                    result = avatarService.findAvatarsById(pattern);
-                } else if (byTooltip) {
-                    result = avatarService.findAvatarsByTooltip(pattern);
-                } else if (byUser) {
-                    result = avatarService.findAvatarsByAssignedUser(pattern);
-                } else {
-                    result = avatarService.getAllAvatars();
-                }
-                return avatarMapper.map(result);
+        runAvatarTask(() -> {
+            List<Avatar> result;
+            if (byId) {
+                result = avatarService.findAvatarsById(pattern);
+            } else if (byTooltip) {
+                result = avatarService.findAvatarsByTooltip(pattern);
+            } else if (byUser) {
+                result = avatarService.findAvatarsByAssignedUser(pattern);
+            } else {
+                result = avatarService.getAllAvatars();
             }
-        };
-
-        searchTask.setOnSucceeded(event -> {
-            avatars.setAll(searchTask.getValue());
-            avatarTableView.getSortOrder().clear();
-        });
-
-        searchTask.setOnFailed(e -> {
-            Throwable t = searchTask.getException();
-            log.error("Avatar search failed", t);
-            ViewHelper.errorDialog("Error", "Avatar search failed: " + t.getMessage());
-        });
-
-        new Thread(searchTask, "SearchAvatarsThread").start();
+            return avatarMapper.map(result);
+        }, "SearchAvatarsThread", "Avatar search failed");
     }
 
     public void onAddAvatar() {
@@ -232,6 +198,25 @@ public class AvatarsController implements Controller<SplitPane> {
         LocalPreferences.TabAvatars tab = localPreferences.getTabAvatars();
         ViewHelper.saveColumnLayout(avatarTableView, tab.getAvatarTableColumnWidths(), tab.getAvatarTableColumnOrder());
         ViewHelper.saveColumnLayout(avatarAssignmentTableView, tab.getAvatarAssignmentTableColumnWidths(), tab.getAvatarAssignmentTableColumnOrder());
+    }
+
+    private void runAvatarTask(Callable<List<AvatarFX>> work, String threadName, String errorLabel) {
+        Task<List<AvatarFX>> task = new Task<>() {
+            @Override
+            protected List<AvatarFX> call() throws Exception {
+                return work.call();
+            }
+        };
+        task.setOnSucceeded(e -> {
+            avatars.setAll(task.getValue());
+            avatarTableView.getSortOrder().clear();
+        });
+        task.setOnFailed(e -> {
+            Throwable t = task.getException();
+            log.error("{}", errorLabel, t);
+            ViewHelper.errorDialog("Error", errorLabel + ": " + t.getMessage());
+        });
+        new Thread(task, threadName).start();
     }
 
     private void loadAvatarImageAsync(AvatarFX avatar) {

--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
@@ -2408,6 +2408,47 @@ public class UserManagementController implements Controller<SplitPane> {
         List<GamePlayerStatsFX> chronological = new ArrayList<>(games);
         Collections.reverse(chronological);
 
+        // Build one series per leaderboard; ratingChanges.leaderboard is now included in the API query.
+        LinkedHashMap<String, XYChart.Series<Number, Number>> seriesMap = new LinkedHashMap<>();
+        int gameNum = 1;
+        for (GamePlayerStatsFX g : chronological) {
+            for (LeaderboardRatingJournalFX journal : g.getLeaderboardRatingJournals()) {
+                LeaderboardFX lb = journal.getLeaderboard();
+                String lbName = lb != null && lb.getTechnicalName() != null ? lb.getTechnicalName()
+                        : lb != null && lb.getNameKey() != null ? lb.getNameKey()
+                        : "unknown";
+                Double beforeMean = journal.getMeanBefore();
+                Double beforeDev = journal.getDeviationBefore();
+                if (beforeMean == null || beforeDev == null) continue;
+                int beforeRating = (int) (beforeMean - 3 * beforeDev);
+                XYChart.Series<Number, Number> series = seriesMap.computeIfAbsent(lbName, n -> {
+                    XYChart.Series<Number, Number> s = new XYChart.Series<>();
+                    s.setName(n);
+                    return s;
+                });
+                series.getData().add(new XYChart.Data<>(gameNum, beforeRating));
+            }
+            gameNum++;
+        }
+        // Append final afterRating for each leaderboard from the newest game
+        if (!chronological.isEmpty()) {
+            GamePlayerStatsFX newest = chronological.get(chronological.size() - 1);
+            for (LeaderboardRatingJournalFX journal : newest.getLeaderboardRatingJournals()) {
+                LeaderboardFX lb = journal.getLeaderboard();
+                String lbName = lb != null && lb.getTechnicalName() != null ? lb.getTechnicalName()
+                        : lb != null && lb.getNameKey() != null ? lb.getNameKey()
+                        : "unknown";
+                Double afterMean = journal.getMeanAfter();
+                Double afterDev = journal.getDeviationAfter();
+                if (afterMean == null || afterDev == null) continue;
+                int afterRating = (int) (afterMean - 3 * afterDev);
+                XYChart.Series<Number, Number> s = seriesMap.get(lbName);
+                if (s != null) s.getData().add(new XYChart.Data<>(gameNum, afterRating));
+            }
+        }
+
+        int totalPoints = seriesMap.values().stream().mapToInt(s -> s.getData().size()).sum();
+
         NumberAxis xAxis = new NumberAxis();
         xAxis.setLabel("Game (oldest → newest)");
         xAxis.setTickLabelsVisible(false);
@@ -2422,37 +2463,22 @@ public class UserManagementController implements Controller<SplitPane> {
         LineChart<Number, Number> chart = new LineChart<>(xAxis, yAxis);
         chart.setTitle("Rating History — " + playerName + " (last " + games.size() + " games)");
         chart.setAnimated(false);
-        chart.setLegendVisible(false);
-        chart.setCreateSymbols(games.size() <= 150);
+        chart.setLegendVisible(seriesMap.size() > 1);
+        chart.setCreateSymbols(totalPoints <= 150);
         chart.setPrefWidth(840);
         chart.setPrefHeight(420);
-
-        XYChart.Series<Number, Number> series = new XYChart.Series<>();
-        int gameNum = 1;
-        for (GamePlayerStatsFX g : chronological) {
-            Integer before = g.beforeRatingProperty().get();
-            if (before != null) {
-                XYChart.Data<Number, Number> point = new XYChart.Data<>(gameNum, before);
-                series.getData().add(point);
-            }
-            gameNum++;
-        }
-        // Append final afterRating of the newest game so the line reaches the current rating
-        if (!chronological.isEmpty()) {
-            Integer afterLast = chronological.get(chronological.size() - 1).afterRatingProperty().get();
-            if (afterLast != null) {
-                series.getData().add(new XYChart.Data<>(gameNum, afterLast));
-            }
-        }
-        chart.getData().add(series);
+        chart.getData().addAll(seriesMap.values());
 
         // Tooltips on data points (added after node is created)
-        for (XYChart.Data<Number, Number> dp : series.getData()) {
-            dp.nodeProperty().addListener((obs, oldNode, node) -> {
-                if (node != null) {
-                    Tooltip.install(node, new Tooltip("Game " + dp.getXValue() + ": " + dp.getYValue().intValue()));
-                }
-            });
+        for (XYChart.Series<Number, Number> series : seriesMap.values()) {
+            for (XYChart.Data<Number, Number> dp : series.getData()) {
+                String label = series.getName() + ": " + dp.getYValue().intValue();
+                dp.nodeProperty().addListener((obs, oldNode, node) -> {
+                    if (node != null) {
+                        Tooltip.install(node, new Tooltip(label));
+                    }
+                });
+            }
         }
 
         // --- Tabbed dialog ---

--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
@@ -43,6 +43,9 @@ import javafx.scene.text.Text;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.geometry.Point2D;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
@@ -2297,116 +2300,155 @@ public class UserManagementController implements Controller<SplitPane> {
                 .findFirst()
                 .orElse("Unknown");
 
-        int flagCount = 0;
-        StringBuilder report = new StringBuilder();
-        report.append(String.format("Analyzed %d games (%d with rating data) for: %s%n%n",
-                games.size(), ratedGames.size(), playerName));
-        report.append(String.format("%-8s %-45s %s%n", "Status", "Check", "Value"));
-        report.append("─".repeat(90)).append("\n");
-
-        // Check 1: Loss rate
-        long losses = ratedGames.stream()
-                .filter(g -> g.ratingChangeProperty().get().doubleValue() < 0)
-                .count();
-        double lossRate = (double) losses / ratedGames.size() * 100.0;
-        boolean lossRateFlag = lossRate > 70.0;
-        if (lossRateFlag) flagCount++;
-        report.append(formatCheckLine(lossRateFlag,
-                "Loss Rate (threshold: >70%)",
-                String.format("%.1f%% (%d / %d games)", lossRate, losses, ratedGames.size())));
-
-        // Check 2: Net rating trend across analyzed games
-        List<GamePlayerStatsFX> withFullRating = ratedGames.stream()
-                .filter(g -> g.beforeRatingProperty().get() != null && g.afterRatingProperty().get() != null)
-                .toList();
-        int netRatingChange = 0;
-        boolean netRatingFlag = false;
-        if (!withFullRating.isEmpty()) {
-            // games sorted newest-first; last entry = oldest
-            int newestAfter = withFullRating.get(0).afterRatingProperty().get();
-            int oldestBefore = withFullRating.get(withFullRating.size() - 1).beforeRatingProperty().get();
-            netRatingChange = newestAfter - oldestBefore;
-            netRatingFlag = netRatingChange < -200;
-            if (netRatingFlag) flagCount++;
-        }
-        report.append(formatCheckLine(netRatingFlag,
-                "Net Rating Change (threshold: <-200)",
-                String.format("%+d points", netRatingChange)));
-
-        // Check 3: Max consecutive loss streak
-        int maxStreak = 0, currentStreak = 0;
-        for (GamePlayerStatsFX g : ratedGames) {
-            if (g.ratingChangeProperty().get().doubleValue() < 0) {
-                currentStreak++;
-                maxStreak = Math.max(maxStreak, currentStreak);
-            } else {
-                currentStreak = 0;
-            }
-        }
-        boolean streakFlag = maxStreak >= 10;
-        if (streakFlag) flagCount++;
-        report.append(formatCheckLine(streakFlag,
-                "Longest Consecutive Loss Streak (threshold: >=10)",
-                maxStreak + " games in a row"));
-
-        // Check 4: Heavy per-game rating drops
-        long heavyDrops = ratedGames.stream()
-                .filter(g -> g.ratingChangeProperty().get().doubleValue() <= -20)
-                .count();
-        boolean heavyDropFlag = heavyDrops >= 10;
-        if (heavyDropFlag) flagCount++;
-        report.append(formatCheckLine(heavyDropFlag,
-                "Games With Drop >= -20 Rating (threshold: >=10 games)",
-                heavyDrops + " games"));
-
-        // Check 5: Invalid game ratio
-        long invalidCount = games.stream()
-                .filter(g -> g.getGame() != null
-                        && g.getGame().getValidity() != null
-                        && g.getGame().getValidity() != Validity.VALID)
-                .count();
-        double invalidRate = (double) invalidCount / games.size() * 100.0;
-        boolean invalidFlag = invalidRate > 15.0;
-        if (invalidFlag) flagCount++;
-        report.append(formatCheckLine(invalidFlag,
-                "Invalid Games Ratio (threshold: >15%)",
-                String.format("%.1f%% (%d / %d games)", invalidRate, invalidCount, games.size())));
-
-        // Check 6: Low/zero score pattern
-        List<GamePlayerStatsFX> scoredGames = games.stream()
-                .filter(g -> g.getScore() != null)
-                .toList();
-        if (!scoredGames.isEmpty()) {
-            long lowScoreCount = scoredGames.stream()
-                    .filter(g -> g.getScore() <= 0)
-                    .count();
-            double lowScoreRate = (double) lowScoreCount / scoredGames.size() * 100.0;
-            boolean lowScoreFlag = lowScoreRate > 40.0;
-            if (lowScoreFlag) flagCount++;
-            report.append(formatCheckLine(lowScoreFlag,
-                    "Low/Zero Score Games (threshold: >40%)",
-                    String.format("%.1f%% (%d / %d scored games)", lowScoreRate, lowScoreCount, scoredGames.size())));
+        // --- Settings tab: threshold spinners ---
+        Spinner<Double> spLossRate     = new Spinner<>(new SpinnerValueFactory.DoubleSpinnerValueFactory(0, 100, 70, 5));
+        Spinner<Integer> spNetRating   = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(-5000, -1, -200, 50));
+        Spinner<Integer> spStreak      = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 200, 10, 1));
+        Spinner<Integer> spDropPerGame = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 500, 20, 5));
+        Spinner<Integer> spDropCount   = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(1, 200, 10, 1));
+        Spinner<Double> spInvalidRatio = new Spinner<>(new SpinnerValueFactory.DoubleSpinnerValueFactory(0, 100, 15, 5));
+        Spinner<Double> spLowScore     = new Spinner<>(new SpinnerValueFactory.DoubleSpinnerValueFactory(0, 100, 40, 5));
+        for (Spinner<?> sp : List.of(spLossRate, spNetRating, spStreak, spDropPerGame, spDropCount, spInvalidRatio, spLowScore)) {
+            sp.setEditable(true);
+            sp.setPrefWidth(110);
         }
 
-        report.append("─".repeat(90)).append("\n");
-
-        String verdict;
-        if (flagCount == 0) {
-            verdict = "VERDICT: CLEAN — No suspicious patterns detected.";
-        } else if (flagCount <= 2) {
-            verdict = String.format("VERDICT: SUSPICIOUS — %d indicator(s) flagged. Manual review recommended.", flagCount);
-        } else {
-            verdict = String.format("VERDICT: HIGH RISK — %d indicators flagged. Strong signs of rating manipulation.", flagCount);
+        GridPane settingsGrid = new GridPane();
+        settingsGrid.setHgap(12);
+        settingsGrid.setVgap(8);
+        settingsGrid.setPadding(new Insets(16));
+        String[][] settingsRows = {
+            {"Loss Rate flag when above (%)",             "default: 70"},
+            {"Net Rating Change flag when below (pts)",   "default: −200"},
+            {"Consecutive Loss Streak flag when >= (games)", "default: 10"},
+            {"Per-game Rating Drop flag threshold (pts)", "default: 20"},
+            {"Count of such drops to flag (games)",       "default: 10"},
+            {"Invalid Games Ratio flag when above (%)",   "default: 15"},
+            {"Low/Zero Score Games flag when above (%)",  "default: 40"},
+        };
+        Spinner<?>[] spinners = {spLossRate, spNetRating, spStreak, spDropPerGame, spDropCount, spInvalidRatio, spLowScore};
+        for (int i = 0; i < settingsRows.length; i++) {
+            settingsGrid.add(new Label(settingsRows[i][0]), 0, i);
+            settingsGrid.add(spinners[i], 1, i);
+            Label hint = new Label(settingsRows[i][1]);
+            hint.setStyle("-fx-text-fill: gray; -fx-font-size: 11;");
+            settingsGrid.add(hint, 2, i);
         }
-        report.append("\n").append(verdict).append("\n");
 
         // --- Analysis tab ---
-        TextArea textArea = new TextArea(report.toString());
+        TextArea textArea = new TextArea();
         textArea.setEditable(false);
         textArea.setWrapText(false);
         textArea.setStyle("-fx-font-family: monospace; -fx-font-size: 12;");
         textArea.setPrefWidth(840);
         textArea.setPrefHeight(420);
+
+        // Recomputes the analysis text from the current spinner values and updates textArea
+        final List<GamePlayerStatsFX> gamesFinal = games;
+        final List<GamePlayerStatsFX> ratedGamesFinal = ratedGames;
+        Runnable runAnalysis = () -> {
+            double lossRatePct  = spLossRate.getValue();
+            int netRatingMin    = spNetRating.getValue();
+            int streakMin       = spStreak.getValue();
+            int dropPerGame     = spDropPerGame.getValue();
+            int dropCountMin    = spDropCount.getValue();
+            double invalidPct   = spInvalidRatio.getValue();
+            double lowScorePct  = spLowScore.getValue();
+
+            int fc = 0;
+            StringBuilder report = new StringBuilder();
+            report.append(String.format("Analyzed %d games (%d with rating data) for: %s%n%n",
+                    gamesFinal.size(), ratedGamesFinal.size(), playerName));
+            report.append(String.format("%-8s %-55s %s%n", "Status", "Check", "Value"));
+            report.append("─".repeat(100)).append("\n");
+
+            // Check 1: Loss rate
+            long losses = ratedGamesFinal.stream()
+                    .filter(g -> g.ratingChangeProperty().get().doubleValue() < 0)
+                    .count();
+            double lossRate = (double) losses / ratedGamesFinal.size() * 100.0;
+            boolean lossRateFlag = lossRate > lossRatePct;
+            if (lossRateFlag) fc++;
+            report.append(formatCheckLine(lossRateFlag,
+                    String.format("Loss Rate (threshold: >%.0f%%)", lossRatePct),
+                    String.format("%.1f%% (%d / %d games)", lossRate, losses, ratedGamesFinal.size())));
+
+            // Check 2: Net rating trend
+            List<GamePlayerStatsFX> withFull = ratedGamesFinal.stream()
+                    .filter(g -> g.beforeRatingProperty().get() != null && g.afterRatingProperty().get() != null)
+                    .toList();
+            int netRatingChange = 0;
+            boolean netRatingFlag = false;
+            if (!withFull.isEmpty()) {
+                int newestAfter = withFull.get(0).afterRatingProperty().get();
+                int oldestBefore = withFull.get(withFull.size() - 1).beforeRatingProperty().get();
+                netRatingChange = newestAfter - oldestBefore;
+                netRatingFlag = netRatingChange < netRatingMin;
+                if (netRatingFlag) fc++;
+            }
+            report.append(formatCheckLine(netRatingFlag,
+                    String.format("Net Rating Change (threshold: <%d)", netRatingMin),
+                    String.format("%+d points", netRatingChange)));
+
+            // Check 3: Max consecutive loss streak
+            int maxStreak = 0, cur = 0;
+            for (GamePlayerStatsFX g : ratedGamesFinal) {
+                if (g.ratingChangeProperty().get().doubleValue() < 0) { cur++; maxStreak = Math.max(maxStreak, cur); }
+                else cur = 0;
+            }
+            boolean streakFlag = maxStreak >= streakMin;
+            if (streakFlag) fc++;
+            report.append(formatCheckLine(streakFlag,
+                    String.format("Longest Consecutive Loss Streak (threshold: >=%d)", streakMin),
+                    maxStreak + " games in a row"));
+
+            // Check 4: Heavy per-game rating drops
+            long heavyDrops = ratedGamesFinal.stream()
+                    .filter(g -> g.ratingChangeProperty().get().doubleValue() <= -dropPerGame)
+                    .count();
+            boolean heavyDropFlag = heavyDrops >= dropCountMin;
+            if (heavyDropFlag) fc++;
+            report.append(formatCheckLine(heavyDropFlag,
+                    String.format("Games With Drop >= -%d Rating (threshold: >=%d games)", dropPerGame, dropCountMin),
+                    heavyDrops + " games"));
+
+            // Check 5: Invalid game ratio
+            long invalidCount = gamesFinal.stream()
+                    .filter(g -> g.getGame() != null
+                            && g.getGame().getValidity() != null
+                            && g.getGame().getValidity() != Validity.VALID)
+                    .count();
+            double invalidRate = (double) invalidCount / gamesFinal.size() * 100.0;
+            boolean invalidFlag = invalidRate > invalidPct;
+            if (invalidFlag) fc++;
+            report.append(formatCheckLine(invalidFlag,
+                    String.format("Invalid Games Ratio (threshold: >%.0f%%)", invalidPct),
+                    String.format("%.1f%% (%d / %d games)", invalidRate, invalidCount, gamesFinal.size())));
+
+            // Check 6: Low/zero score pattern
+            List<GamePlayerStatsFX> scoredGames = gamesFinal.stream()
+                    .filter(g -> g.getScore() != null).toList();
+            if (!scoredGames.isEmpty()) {
+                long lowScoreCount = scoredGames.stream().filter(g -> g.getScore() <= 0).count();
+                double lowScoreRate = (double) lowScoreCount / scoredGames.size() * 100.0;
+                boolean lowScoreFlag = lowScoreRate > lowScorePct;
+                if (lowScoreFlag) fc++;
+                report.append(formatCheckLine(lowScoreFlag,
+                        String.format("Low/Zero Score Games (threshold: >%.0f%%)", lowScorePct),
+                        String.format("%.1f%% (%d / %d scored games)", lowScoreRate, lowScoreCount, scoredGames.size())));
+            }
+
+            report.append("─".repeat(100)).append("\n");
+            String verdict;
+            if (fc == 0)       verdict = "VERDICT: CLEAN — No suspicious patterns detected.";
+            else if (fc <= 2)  verdict = String.format("VERDICT: SUSPICIOUS — %d indicator(s) flagged. Manual review recommended.", fc);
+            else               verdict = String.format("VERDICT: HIGH RISK — %d indicators flagged. Strong signs of rating manipulation.", fc);
+            report.append("\n").append(verdict).append("\n");
+            textArea.setText(report.toString());
+        };
+
+        runAnalysis.run();
+        for (Spinner<?> sp : spinners) sp.valueProperty().addListener((obs, o, n) -> runAnalysis.run());
 
         // --- Rating History chart tab ---
         // Reverse so index 0 = oldest game (left of chart)
@@ -2587,8 +2629,10 @@ public class UserManagementController implements Controller<SplitPane> {
         analysisTab.setClosable(false);
         Tab chartTab = new Tab("Rating History", chartContainer);
         chartTab.setClosable(false);
+        Tab settingsTab = new Tab("Settings", settingsGrid);
+        settingsTab.setClosable(false);
 
-        TabPane tabPane = new TabPane(analysisTab, chartTab);
+        TabPane tabPane = new TabPane(analysisTab, chartTab, settingsTab);
 
         Dialog<ButtonType> dialog = new Dialog<>();
         dialog.setTitle("Rating Manipulation Analysis — " + playerName);

--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
@@ -42,6 +42,11 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.geometry.Point2D;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 import javafx.util.StringConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -2408,10 +2413,23 @@ public class UserManagementController implements Controller<SplitPane> {
         List<GamePlayerStatsFX> chronological = new ArrayList<>(games);
         Collections.reverse(chronological);
 
-        // Build one series per leaderboard; ratingChanges.leaderboard is now included in the API query.
+        // Build one series per leaderboard, using epoch-seconds as X so the axis shows real dates.
         LinkedHashMap<String, XYChart.Series<Number, Number>> seriesMap = new LinkedHashMap<>();
-        int gameNum = 1;
+        // Parallel map: epoch-second → formatted date string, for tooltips
+        LinkedHashMap<Long, String> epochToLabel = new LinkedHashMap<>();
+        long minEpoch = Long.MAX_VALUE;
+        long maxEpoch = Long.MIN_VALUE;
+
         for (GamePlayerStatsFX g : chronological) {
+            OffsetDateTime time = g.getScoreTime();
+            if (time == null && g.getGame() != null) time = g.getGame().getStartTime();
+            if (time == null) continue;
+            long epochSec = time.toEpochSecond();
+            minEpoch = Math.min(minEpoch, epochSec);
+            maxEpoch = Math.max(maxEpoch, epochSec);
+            epochToLabel.put(epochSec,
+                    time.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+
             for (LeaderboardRatingJournalFX journal : g.getLeaderboardRatingJournals()) {
                 LeaderboardFX lb = journal.getLeaderboard();
                 String lbName = lb != null && lb.getTechnicalName() != null ? lb.getTechnicalName()
@@ -2426,13 +2444,15 @@ public class UserManagementController implements Controller<SplitPane> {
                     s.setName(n);
                     return s;
                 });
-                series.getData().add(new XYChart.Data<>(gameNum, beforeRating));
+                series.getData().add(new XYChart.Data<>(epochSec, beforeRating));
             }
-            gameNum++;
         }
         // Append final afterRating for each leaderboard from the newest game
         if (!chronological.isEmpty()) {
             GamePlayerStatsFX newest = chronological.get(chronological.size() - 1);
+            OffsetDateTime newestTime = newest.getScoreTime();
+            if (newestTime == null && newest.getGame() != null) newestTime = newest.getGame().getStartTime();
+            long newestEpoch = newestTime != null ? newestTime.toEpochSecond() + 1 : maxEpoch + 1;
             for (LeaderboardRatingJournalFX journal : newest.getLeaderboardRatingJournals()) {
                 LeaderboardFX lb = journal.getLeaderboard();
                 String lbName = lb != null && lb.getTechnicalName() != null ? lb.getTechnicalName()
@@ -2443,17 +2463,29 @@ public class UserManagementController implements Controller<SplitPane> {
                 if (afterMean == null || afterDev == null) continue;
                 int afterRating = (int) (afterMean - 3 * afterDev);
                 XYChart.Series<Number, Number> s = seriesMap.get(lbName);
-                if (s != null) s.getData().add(new XYChart.Data<>(gameNum, afterRating));
+                if (s != null) s.getData().add(new XYChart.Data<>(newestEpoch, afterRating));
             }
         }
 
         int totalPoints = seriesMap.values().stream().mapToInt(s -> s.getData().size()).sum();
 
-        NumberAxis xAxis = new NumberAxis();
-        xAxis.setLabel("Game (oldest → newest)");
-        xAxis.setTickLabelsVisible(false);
+        // Compute tick unit: aim for ~8 labelled ticks, rounded to whole days
+        long rangeSeconds = minEpoch == Long.MAX_VALUE ? 86400L : Math.max(86400L, maxEpoch - minEpoch);
+        long tickUnit = Math.max(86400L, (rangeSeconds / 8 / 86400 + 1) * 86400L);
+        long axisMin = minEpoch == Long.MAX_VALUE ? 0L : minEpoch - 86400L;
+        long axisMax = minEpoch == Long.MAX_VALUE ? 86400L : maxEpoch + 86400L;
+
+        DateTimeFormatter axisDateFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        NumberAxis xAxis = new NumberAxis(axisMin, axisMax, tickUnit);
+        xAxis.setLabel("Date");
         xAxis.setMinorTickVisible(false);
-        xAxis.setAutoRanging(true);
+        xAxis.setTickLabelRotation(40);
+        xAxis.setTickLabelFormatter(new StringConverter<>() {
+            @Override public String toString(Number v) {
+                return Instant.ofEpochSecond(v.longValue()).atZone(ZoneId.systemDefault()).format(axisDateFmt);
+            }
+            @Override public Number fromString(String s) { return null; }
+        });
 
         NumberAxis yAxis = new NumberAxis();
         yAxis.setLabel("Rating");
@@ -2466,25 +2498,94 @@ public class UserManagementController implements Controller<SplitPane> {
         chart.setLegendVisible(seriesMap.size() > 1);
         chart.setCreateSymbols(totalPoints <= 150);
         chart.setPrefWidth(840);
-        chart.setPrefHeight(420);
+        chart.setPrefHeight(440);
         chart.getData().addAll(seriesMap.values());
 
-        // Tooltips on data points (added after node is created)
+        // Tooltips: include date + leaderboard + rating
         for (XYChart.Series<Number, Number> series : seriesMap.values()) {
             for (XYChart.Data<Number, Number> dp : series.getData()) {
-                String label = series.getName() + ": " + dp.getYValue().intValue();
+                String dateLabel = epochToLabel.getOrDefault(dp.getXValue().longValue(), "");
+                String label = (dateLabel.isEmpty() ? "" : dateLabel + "\n")
+                        + series.getName() + ": " + dp.getYValue().intValue();
                 dp.nodeProperty().addListener((obs, oldNode, node) -> {
-                    if (node != null) {
-                        Tooltip.install(node, new Tooltip(label));
-                    }
+                    if (node != null) Tooltip.install(node, new Tooltip(label));
                 });
             }
         }
 
+        // Drag-select zoom: draw a selection box; on release, zoom to that region.
+        // Double-click resets to full view.
+        Rectangle selectionRect = new Rectangle(0, 0, 0, 0);
+        selectionRect.setFill(Color.CORNFLOWERBLUE.deriveColor(0, 1, 1, 0.25));
+        selectionRect.setStroke(Color.CORNFLOWERBLUE);
+        selectionRect.setStrokeWidth(1);
+        selectionRect.setVisible(false);
+        selectionRect.setMouseTransparent(true);
+        Pane overlay = new Pane(selectionRect);
+        overlay.setMouseTransparent(true);
+        StackPane chartContainer = new StackPane(chart, overlay);
+
+        final double[] dragAnchor = {0, 0};
+        chart.setOnMousePressed(e -> {
+            if (e.isPrimaryButtonDown()) {
+                dragAnchor[0] = e.getX();
+                dragAnchor[1] = e.getY();
+                selectionRect.setX(e.getX());
+                selectionRect.setY(e.getY());
+                selectionRect.setWidth(0);
+                selectionRect.setHeight(0);
+                selectionRect.setVisible(true);
+            }
+        });
+        chart.setOnMouseDragged(e -> {
+            if (e.isPrimaryButtonDown()) {
+                double x = Math.min(e.getX(), dragAnchor[0]);
+                double y = Math.min(e.getY(), dragAnchor[1]);
+                selectionRect.setX(x);
+                selectionRect.setY(y);
+                selectionRect.setWidth(Math.abs(e.getX() - dragAnchor[0]));
+                selectionRect.setHeight(Math.abs(e.getY() - dragAnchor[1]));
+            }
+        });
+        chart.setOnMouseReleased(e -> {
+            if (!selectionRect.isVisible()) return;
+            selectionRect.setVisible(false);
+            double w = selectionRect.getWidth();
+            double h = selectionRect.getHeight();
+            if (w < 10 || h < 10) return; // ignore tiny drags / clicks
+            // Convert chart-local pixel coords to data values via axis coordinate transforms
+            double x1 = selectionRect.getX();
+            double x2 = x1 + w;
+            double y1 = selectionRect.getY();
+            double y2 = y1 + h;
+            double dataX1 = xAxis.getValueForDisplay(xAxis.sceneToLocal(chart.localToScene(x1, y1)).getX()).doubleValue();
+            double dataX2 = xAxis.getValueForDisplay(xAxis.sceneToLocal(chart.localToScene(x2, y1)).getX()).doubleValue();
+            double dataY1 = yAxis.getValueForDisplay(yAxis.sceneToLocal(chart.localToScene(x1, y1)).getY()).doubleValue();
+            double dataY2 = yAxis.getValueForDisplay(yAxis.sceneToLocal(chart.localToScene(x1, y2)).getY()).doubleValue();
+            long newMin = (long) Math.min(dataX1, dataX2);
+            long newMax = (long) Math.max(dataX1, dataX2);
+            long newTickUnit = Math.max(3600L, (newMax - newMin) / 8);
+            xAxis.setLowerBound(newMin);
+            xAxis.setUpperBound(newMax);
+            xAxis.setTickUnit(newTickUnit);
+            yAxis.setAutoRanging(false);
+            yAxis.setLowerBound(Math.min(dataY1, dataY2));
+            yAxis.setUpperBound(Math.max(dataY1, dataY2));
+        });
+        // Double-click resets zoom to the full data range
+        chart.setOnMouseClicked(e -> {
+            if (e.getClickCount() == 2) {
+                xAxis.setLowerBound(axisMin);
+                xAxis.setUpperBound(axisMax);
+                xAxis.setTickUnit(tickUnit);
+                yAxis.setAutoRanging(true);
+            }
+        });
+
         // --- Tabbed dialog ---
         Tab analysisTab = new Tab("Analysis", textArea);
         analysisTab.setClosable(false);
-        Tab chartTab = new Tab("Rating History", chart);
+        Tab chartTab = new Tab("Rating History", chartContainer);
         chartTab.setClosable(false);
 
         TabPane tabPane = new TabPane(analysisTab, chartTab);

--- a/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
@@ -1315,13 +1315,17 @@ public class ModerationReportController implements Controller<Region> {
             return;
         }
 
-        if (selectedItems.size() > 5) {
-            if (!showConfirmationDialog(selectedItems.size())) {
+        // Snapshot before any dialogs — showAndWait() pumps the event loop and a
+        // background refresh could clear itemList and reset the selection mid-wait.
+        List<ModerationReportFX> snapshot = new ArrayList<>(selectedItems);
+
+        if (snapshot.size() > 5) {
+            if (!showConfirmationDialog(snapshot.size())) {
                 return;
             }
         }
 
-        openEditDialog(selectedItems);
+        openEditDialog(snapshot);
     }
 
     private boolean showConfirmationDialog(int numberOfReports) {
@@ -1367,10 +1371,10 @@ public class ModerationReportController implements Controller<Region> {
         return result.isPresent() && result.get() == confirmButtonType;
     }
 
-    private void openEditDialog(ObservableList<ModerationReportFX> selectedItems) {
+    private void openEditDialog(List<ModerationReportFX> selectedItems) {
         try {
             EditModerationReportController editModerationReportController = uiService.loadFxml("ui/edit_moderation_report.fxml");
-            editModerationReportController.setSelectedReports(new ArrayList<>(selectedItems));
+            editModerationReportController.setSelectedReports(selectedItems);
 
             Stage editDialog = new Stage();
             int numberOfReports = selectedItems.size();

--- a/src/main/resources/ui/main_window/avatars.fxml
+++ b/src/main/resources/ui/main_window/avatars.fxml
@@ -7,7 +7,7 @@
     <items>
         <VBox>
             <children>
-                <HBox maxHeight="1.7976931348623157E308">
+                <HBox maxHeight="1.7976931348623157E308" VBox.vgrow="ALWAYS">
                     <children>
                         <VBox maxHeight="1.7976931348623157E308">
                             <children>


### PR DESCRIPTION
## Changelog

### Features
- **Rating History chart — per-leaderboard series** (`f4fed84`)
  Each leaderboard (global, ladder_1v1, tmm_2v2, ...) now gets its own coloured series. The X-axis shows real dates; tooltips include date + leaderboard name + rating. Drag a box to zoom in, double-click to reset. `ratingChanges.leaderboard` is now fetched so leaderboard names are always populated.

- **Configurable thresholds in Rating Manipulation dialog** (`f25a665`)
  A new *Settings* tab exposes all six analysis thresholds as editable spinners. Changing any value instantly re-runs the analysis. Defaults are unchanged.

- **Avatar table: assignment count and in-use stats columns** (`0c9b5b2`)

### Bug Fixes
- **`GameFX` / `GamePlayerStatsFX` id field shadow** (`aece01e`) — shadow field broke `equals`/`hashCode` in hash-based collections. Removed.
- **`GamePlayerStatsFX` NPE and broken bindings** (`7b3850c`) — prevented NPE in rating property getters and binding relationships.
- **`GameFX.getReplayUrl()` NPE** (`727912f`) — null-guard added when `id` property is unset.
- **`MapPoolAssignmentFX.setWeight(null)` NPE** (`071c8b0`) — null `Integer` auto-unboxing now defaults to 0.
- **Bulk report edit skipping last item** (`acb161e`) — multi-selection is snapshotted before the confirmation dialog, preventing a background refresh from clearing it mid-save.
- **Token revocation blocked by Cloudflare** (`6559417`) — revocation is now best-effort; failures no longer block ban operations.
- **Avatars SplitPane top pane not resizable** (`394ebe2`)

### Refactoring / Cleanup
- `FeaturedModFX` now extends `AbstractEntityFX`, removing duplicated id management (`1a15506`)
- `GroupPermissionFX`: removed `@Value` from mutable JavaFX bean (`b67299f`)
- `GameFX.reviews`: removed always-empty dead code and raw DTO reference (`4a7c2bb`)
- `GamePlayerStatsFX`: switched from `InvalidationListener` to `ListChangeListener` (`c09c1e6`)
- `MapPoolFX`: removed leftover unused Lombok imports (`aa1fd9c`)
- `LeaderboardRatingJournalFX`: documented null-as-sentinel intent for `ObjectProperty<Double>` fields (`0cab137`)
- `ViewHelper` / `AvatarsController`: eliminated repeated patterns (`25fea1d`)
- `TemplateAndReasonConfig`: removed redundant `@Getter`/`@Setter` (`49dc5eb`)
- Extracted `tryPost` helper for best-effort HTTP calls (`a03aec4`)

## Test plan
- [ ] Load a player with games across multiple leaderboards — verify Rating History shows one series per leaderboard with correct dates on X-axis
- [ ] Drag-select a region in the Rating History chart — verify zoom; double-click to reset
- [ ] Open Rating Manipulation dialog -> Settings tab — adjust a threshold and confirm Analysis tab updates immediately
- [ ] Bulk-select 6+ moderation reports, edit and save — confirm all reports including the last are updated
- [ ] Verify avatars table shows assignment count columns
- [ ] Confirm no NPE on players with no rating journal data

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable threshold settings for rating manipulation analysis
  * Interactive rating history chart with multi-leaderboard tracking, real-time dates, and drag-zoom capability

* **Improvements**
  * Enhanced ban operations resilience against network issues
  * Improved user data table formatting and display clarity
  * Streamlined avatar task execution with centralized error handling

* **Bug Fixes**
  * Fixed race condition in moderation report selection during bulk editing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magge-faf/faf-moderator-client-develop-modified/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->