### PR TITLE
Reports UI improvements and user-management fixes

### DIFF
--- a/src/main/java/com/faforever/moderatorclient/config/local/LocalPreferences.java
+++ b/src/main/java/com/faforever/moderatorclient/config/local/LocalPreferences.java
@@ -653,6 +653,7 @@ public class LocalPreferences {
         boolean fetchReportsOnStartupCheckBox = true;
         boolean enableManualReplayLookupCheckBox = false;
         boolean showReportPlayerRoleLabelsCheckBox = true;
+        boolean autoSearchReportedAccountInUserManagementCheckBox = false;
 
         // TextFields
         String thresholdToShowSelfDestructionUnitsEventTextField = "0";

--- a/src/main/java/com/faforever/moderatorclient/mapstruct/AvatarAssignmentMapper.java
+++ b/src/main/java/com/faforever/moderatorclient/mapstruct/AvatarAssignmentMapper.java
@@ -3,13 +3,16 @@ package com.faforever.moderatorclient.mapstruct;
 import com.faforever.commons.api.dto.AvatarAssignment;
 import com.faforever.moderatorclient.ui.domain.AvatarAssignmentFX;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
 @Mapper(componentModel = "spring", uses = {JavaFXMapper.class, AvatarMapper.class, PlayerMapper.class, CycleAvoidingMappingContext.class})
 public abstract class AvatarAssignmentMapper {
+    @Mapping(target = "selected", ignore = true)
     public abstract AvatarAssignmentFX map(AvatarAssignment dto);
 
+    @Mapping(target = "selected", ignore = true)
     public abstract AvatarAssignment map(AvatarAssignmentFX fxBean);
 
     public abstract List<AvatarAssignmentFX> mapToFX(List<AvatarAssignment> dtoList);

--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
@@ -658,6 +658,16 @@ public class UserManagementController implements Controller<SplitPane> {
         new Thread(searchTask).start();
     }
 
+    public void searchUserByLogin(String login) {
+        if (login == null || login.isBlank()) {
+            return;
+        }
+
+        searchUserProperties.getSelectionModel().select("Name");
+        userSearchTextField.setText(login);
+        onUserSearch();
+    }
+
     private String determineSearchParameter(String searchPattern) {
         if (isDeviceId(searchPattern)) {
             return "uniqueIdAssignments.uniqueId.deviceId";

--- a/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/main_window/UserManagementController.java
@@ -600,9 +600,7 @@ public class UserManagementController implements Controller<SplitPane> {
     }
 
     public void onUserSearch() {
-        users.clear();
-        userSearchTableView.getSortOrder().clear();
-        searchHighlightTerm.set(null);
+        clearUserSearchResults();
 
         String searchParameter = searchUserPropertyMapping.get(searchUserProperties.getValue());
         String searchPattern = userSearchTextField.getText();
@@ -1008,6 +1006,13 @@ public class UserManagementController implements Controller<SplitPane> {
         }
     }
 
+    private void clearUserSearchResults() {
+        users.clear();
+        userSearchTableView.getSortOrder().clear();
+        userSearchTableView.getSelectionModel().clearSelection();
+        searchHighlightTerm.set(null);
+    }
+
     private boolean isValidPlayerId(String playerId) {
         if (playerId == null || playerId.isEmpty()) {
             return false;
@@ -1191,6 +1196,7 @@ public class UserManagementController implements Controller<SplitPane> {
 
     private void processBannedUsers(Path filePath, Label progressLabel, String taskName) {
         captureSmurfCheckSettings(false);
+        clearUserSearchResults();
         resetPreviousStateSmurfVillageLookup();
         Set<String> userIds = bansController.loadExistingBannedUserIds(filePath);
 
@@ -1983,8 +1989,7 @@ public class UserManagementController implements Controller<SplitPane> {
 
     private void startSmurfVillageLookup(boolean forceEnableAllSettings) {
         captureSmurfCheckSettings(forceEnableAllSettings);
-        users.clear();
-        userSearchTableView.getSortOrder().clear();
+        clearUserSearchResults();
 
         setStatusWorking();
 
@@ -2114,8 +2119,7 @@ public class UserManagementController implements Controller<SplitPane> {
 
         captureSmurfCheckSettings(false);
         smurfLookupSettings = smurfLookupSettings.withSuppressCleanOutput(true);
-        users.clear();
-        userSearchTableView.getSortOrder().clear();
+        clearUserSearchResults();
         resetPreviousStateSmurfVillageLookup();
         smurfOutputTextArea.setText("");
         stopLoadingAnimation();

--- a/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
+++ b/src/main/java/com/faforever/moderatorclient/ui/moderation_reports/ModerationReportController.java
@@ -2,6 +2,7 @@ package com.faforever.moderatorclient.ui.moderation_reports;
 
 import com.faforever.moderatorclient.ui.moderation_reports.ModeratorStatisticsFormatter.ModeratorActivity;
 import com.faforever.moderatorclient.ui.main_window.ReportStatisticsController;
+import com.faforever.moderatorclient.ui.main_window.UserManagementController;
 import com.faforever.commons.api.dto.ModerationReportStatus;
 import com.faforever.commons.replay.ChatMessage;
 import com.faforever.commons.replay.ModeratorEvent;
@@ -59,10 +60,13 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.StrokeLineCap;
 import javafx.scene.shape.StrokeLineJoin;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -114,6 +118,8 @@ public class ModerationReportController implements Controller<Region> {
     private static final String DEMORALIZATION = "demoralization";
     private static final String ASSASSINATION = "Assassination (default)";
     private static final String OFF_STRING = "Off";
+    private static final String REPORTER_TEXT_STYLE = "-fx-text-fill: lightblue;";
+    private static final String OFFENDER_TEXT_STYLE = "-fx-text-fill: lightcoral;";
     private static final ExecutorService BACKGROUND_EXECUTOR = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r);
         t.setDaemon(true);
@@ -228,6 +234,8 @@ public class ModerationReportController implements Controller<Region> {
     @FXML
     public TableView<PlayerFX> reportedPlayerTableView;
     @FXML
+    public CheckBox autoSearchReportedAccountInUserManagementCheckBox;
+    @FXML
     public TextFlow chatLogTextFlow;
     public Button copyReportedUserIdButton;
     public Button copyChatLogButton;
@@ -239,6 +247,9 @@ public class ModerationReportController implements Controller<Region> {
 
     @Autowired
     public ReportStatisticsController reportStatisticsController;
+
+    @Autowired
+    public UserManagementController userManagementController;
 
     @Value("${faforever.vault.replay-download-url-format}")
     private String replayDownLoadFormat;
@@ -937,11 +948,14 @@ public class ModerationReportController implements Controller<Region> {
     @Getter
     @Setter
     public static class Offender {
+        private static final DateTimeFormatter LAST_REPORTED_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
         private final StringProperty player;
         private final Integer currentOffenseCount;
         private final Integer totalOffenseCountCompleted;
         private final Integer totalOffenseCountDiscarded;
         private final Integer totalOffenseCountProcessing;
+        @Getter(AccessLevel.NONE)
         private LocalDateTime lastReported;
 
         public Offender(String player,
@@ -963,18 +977,29 @@ public class ModerationReportController implements Controller<Region> {
             return player.get();
         }
 
+        public String getLastReported() {
+            if (lastReported == null) {
+                return "";
+            }
+            return lastReported.format(LAST_REPORTED_FORMATTER);
+        }
+
     }
 
     private void resetButtonsToInvalidState() {
         resetGameButtonsToInvalidState();
         copyReporterIdButton.setText(formatPlayerRoleButtonText("Reporter", "Reporter n/a"));
+        styleReportAccountButton(copyReporterIdButton, "Reporter");
         copyReporterIdButton.setId("");
         copyReportedUserIdButton.setText(formatPlayerRoleButtonText("Offender", "Reported User n/a"));
+        styleReportAccountButton(copyReportedUserIdButton, "Offender");
         copyReportedUserIdButton.setId("");
         createReportForumReporterButton.setId("");
         createReportForumReporterButton.setText("Search Forum Reporter:\nn/a");
+        styleReportAccountButton(createReportForumReporterButton, "Reporter");
         createReportForumOffenderButton.setId("");
         createReportForumOffenderButton.setText("Search Forum Offender:\nn/a");
+        styleReportAccountButton(createReportForumOffenderButton, "Offender");
         accountPlayersOfCurrentlySelectedReport.clear();
         reportedPlayersOfCurrentlySelectedReport.clear();
     }
@@ -1003,9 +1028,26 @@ public class ModerationReportController implements Controller<Region> {
         TableColumn<PlayerFX, String> roleColumn = new TableColumn<>("Role");
         roleColumn.setId("Role");
         roleColumn.setCellValueFactory(param -> new SimpleStringProperty(getReportAccountRole(param.getValue())));
+        roleColumn.setCellFactory(param -> new TableCell<>() {
+            @Override
+            protected void updateItem(String role, boolean empty) {
+                super.updateItem(role, empty);
+                if (empty || role == null) {
+                    setText(null);
+                    setStyle("");
+                    return;
+                }
+
+                setText(role);
+                setStyle(getReportAccountRoleTextStyle(role));
+            }
+        });
         roleColumn.setPrefWidth(90);
         reportedPlayerTableView.getColumns().addFirst(roleColumn);
         reportedPlayerTableView.getColumns().add(createReportAccountBanColumn());
+        reportedPlayerTableView.getColumns().add(createReportAccountRecentBansColumn());
+        reportedPlayerTableView.getSelectionModel().selectedItemProperty().addListener(
+                (observable, oldValue, newValue) -> autoSearchReportedAccountInUserManagement(newValue));
         Platform.runLater(() -> {
             loadColumnLayout(reportTableView, localPreferences);
             loadSplitPanePositions(root, localPreferences);
@@ -1026,11 +1068,55 @@ public class ModerationReportController implements Controller<Region> {
                 }
 
                 Button button = new Button("Add ban");
+                button.setStyle(getReportAccountRoleTextStyle(getReportAccountRole(item)));
                 button.setOnAction(event -> addBan(item));
                 setGraphic(button);
             }
         });
         return banColumn;
+    }
+
+    private TableColumn<PlayerFX, PlayerFX> createReportAccountRecentBansColumn() {
+        TableColumn<PlayerFX, PlayerFX> bansColumn = new TableColumn<>("Recent Bans");
+        bansColumn.setId("RecentBans");
+        bansColumn.setCellValueFactory(param -> new SimpleObjectProperty<>(param.getValue()));
+        bansColumn.setCellFactory(param -> new TableCell<>() {
+            @Override
+            protected void updateItem(PlayerFX item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty || item == null) {
+                    setGraphic(null);
+                    return;
+                }
+
+                Button button = new Button("Show");
+                button.setDisable(item.getBans().isEmpty());
+                button.setOnAction(event -> showRecentBans(item));
+                setGraphic(button);
+            }
+        });
+        return bansColumn;
+    }
+
+    private void showRecentBans(PlayerFX player) {
+        ObservableList<BanInfoFX> recentBans = FXCollections.observableArrayList(player.getBans().stream()
+                .sorted(Comparator.comparing(BanInfoFX::getCreateTime,
+                        Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+                .toList());
+
+        TableView<BanInfoFX> tableView = new TableView<>();
+        ViewHelper.buildBanTableView(tableView, recentBans, false, localPreferences, userService, uiService);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
+
+        VBox content = new VBox(8);
+        content.setPadding(new Insets(8));
+        content.getChildren().add(tableView);
+
+        Stage dialog = new Stage();
+        dialog.initModality(Modality.NONE);
+        dialog.setTitle("Recent bans - " + player.getRepresentation());
+        dialog.setScene(new Scene(content, 900, 360));
+        dialog.show();
     }
 
     public void onSave() {
@@ -1145,22 +1231,28 @@ public class ModerationReportController implements Controller<Region> {
                 ? "Reporter n/a"
                 : newValue.getReporter().getRepresentation();
         copyReporterIdButton.setText(formatPlayerRoleButtonText("Reporter", reporterRepresentation));
+        styleReportAccountButton(copyReporterIdButton, "Reporter");
         copyReporterIdButton.setId(newValue.getReporter() == null ? "" : reporterRepresentation);
         createReportForumReporterButton.setId(newValue.getReporter() == null ? "" : newValue.getReporter().getId());
         createReportForumReporterButton.setText("Search Forum Reporter:\n" + reporterRepresentation);
+        styleReportAccountButton(createReportForumReporterButton, "Reporter");
 
         // Since ~2023, reports have only one offender; legacy reports may have several.
         for (PlayerFX offender : reportedPlayersOfCurrentlySelectedReport) {
             copyReportedUserIdButton.setId(offender.getRepresentation());
             copyReportedUserIdButton.setText(formatPlayerRoleButtonText("Offender", offender.getRepresentation()));
+            styleReportAccountButton(copyReportedUserIdButton, "Offender");
             createReportForumOffenderButton.setId(offender.getId());
             createReportForumOffenderButton.setText("Search Forum Offender:\n" + offender.getRepresentation());
+            styleReportAccountButton(createReportForumOffenderButton, "Offender");
         }
         if (reportedPlayersOfCurrentlySelectedReport.isEmpty()) {
             copyReportedUserIdButton.setId("");
             copyReportedUserIdButton.setText(formatPlayerRoleButtonText("Offender", "Reported User n/a"));
+            styleReportAccountButton(copyReportedUserIdButton, "Offender");
             createReportForumOffenderButton.setId("");
             createReportForumOffenderButton.setText("Search Forum Offender:\nn/a");
+            styleReportAccountButton(createReportForumOffenderButton, "Offender");
         }
 
         if (newValue.getGame() != null) {
@@ -1202,6 +1294,22 @@ public class ModerationReportController implements Controller<Region> {
         return "Offender";
     }
 
+    private String getReportAccountRoleTextStyle(String role) {
+        return switch (role) {
+            case "Reporter" -> REPORTER_TEXT_STYLE;
+            case "Offender" -> OFFENDER_TEXT_STYLE;
+            default -> "";
+        };
+    }
+
+    private void autoSearchReportedAccountInUserManagement(PlayerFX player) {
+        if (!autoSearchReportedAccountInUserManagementCheckBox.isSelected() || player == null) {
+            return;
+        }
+
+        userManagementController.searchUserByLogin(player.getLogin());
+    }
+
     public void loadCheckboxStates() {
         LocalPreferences.TabReports tabReports = localPreferences.getTabReports();
 
@@ -1219,6 +1327,8 @@ public class ModerationReportController implements Controller<Region> {
         showTextMarkersCheckBox.setSelected(tabReports.isTextMarkerTypeFilterCheckBox());
         thresholdToShowSelfDestructionUnitsEventTextField.setText(tabReports.getThresholdToShowSelfDestructionUnitsEventTextField());
         fetchReportsOnStartupCheckBox.setSelected(tabReports.isFetchReportsOnStartupCheckBox());
+        autoSearchReportedAccountInUserManagementCheckBox.setSelected(
+                tabReports.isAutoSearchReportedAccountInUserManagementCheckBox());
     }
 
     @FXML
@@ -1888,6 +1998,8 @@ public class ModerationReportController implements Controller<Region> {
     // Matches: #N [mm:ss] or [HH:mm:ss] sender → receiver: message
     private static final Pattern CHAT_LINE_PATTERN =
             Pattern.compile("^(#\\d+) (\\[[^\\]]+\\]) (.+?) → (.+?): (.*)$");
+    private static final Pattern MODERATOR_EVENT_LINE_PATTERN =
+            Pattern.compile("^(\\S+) from (.+?)\\s*:\\s*(.*)$");
 
     public void updateChatLogToColorTextFlow(TextFlow textFlow, String filteredLog, String reporterName, String offenderName) {
         if (textFlow == null) {
@@ -2042,42 +2154,65 @@ public class ModerationReportController implements Controller<Region> {
         textFlow.getChildren().clear();
         String[] events = moderatorEvents.split("\n");
 
+        int visibleEventCount = (int) Arrays.stream(events)
+                .filter(event -> event != null && !event.trim().isEmpty())
+                .count();
+        int rowNumberW = Math.max(2, ("#" + visibleEventCount).length());
+        int maxTimeLen = 10;
+        int maxNameLen = 1;
         for (String event : events) {
-            TextFlow eventFlow = new TextFlow();
-            String[] parts = event.split("from ", 2);
+            Matcher matcher = MODERATOR_EVENT_LINE_PATTERN.matcher(event);
+            if (matcher.matches()) {
+                maxTimeLen = Math.max(maxTimeLen, bracketedTime(matcher.group(1)).length());
+                maxNameLen = Math.max(maxNameLen, matcher.group(2).trim().length());
+            }
+        }
+        final int rowW = rowNumberW;
+        final int timeW = maxTimeLen;
+        final int nameW = maxNameLen;
 
-            if (parts.length > 1) {
-                String timestamp = parts[0].trim() + " from ";
-                String rest = parts[1].trim();
-                int colonIndex = rest.indexOf(':');
-
-                if (colonIndex > 0) {
-                    String namePart = rest.substring(0, colonIndex).trim();
-                    String eventMessage = rest.substring(colonIndex + 1).trim();
-
-                    Color nameColor;
-                    if (namePart.equalsIgnoreCase(reporterName)) {
-                        nameColor = Color.LIGHTBLUE;
-                    } else if (namePart.equalsIgnoreCase(offenderName)) {
-                        nameColor = Color.LIGHTCORAL;
-                    } else {
-                        nameColor = Color.WHITE;
-                    }
-
-                    eventFlow.getChildren().addAll(
-                            styledText(timestamp, Color.GRAY),
-                            styledText(namePart + ": ", nameColor),
-                            styledText(eventMessage, Color.WHITE)
-                    );
-                } else {
-                    eventFlow.getChildren().add(styledText(event, Color.WHITE));
-                }
-            } else {
-                eventFlow.getChildren().add(styledText(event, Color.WHITE));
+        int rowNumber = 1;
+        for (String event : events) {
+            if (event == null || event.trim().isEmpty()) {
+                textFlow.getChildren().add(newline());
+                continue;
             }
 
-            textFlow.getChildren().add(eventFlow);
+            String rowNumberPad = String.format("%-" + rowW + "s", "#" + rowNumber++);
+
+            Matcher matcher = MODERATOR_EVENT_LINE_PATTERN.matcher(event);
+            if (matcher.matches()) {
+                String timestamp = String.format("%-" + timeW + "s", bracketedTime(matcher.group(1)));
+                String name = matcher.group(2).trim();
+                String paddedName = String.format("%-" + nameW + "s", name);
+                String eventMessage = matcher.group(3).trim();
+
+                Color nameColor;
+                if (name.equalsIgnoreCase(reporterName)) {
+                    nameColor = Color.LIGHTBLUE;
+                } else if (name.equalsIgnoreCase(offenderName)) {
+                    nameColor = Color.LIGHTCORAL;
+                } else {
+                    nameColor = Color.LIGHTYELLOW;
+                }
+
+                textFlow.getChildren().addAll(
+                        styledText(rowNumberPad + " ", Color.DIMGRAY),
+                        styledText(timestamp + "  ", Color.GRAY),
+                        styledText(paddedName + "  ", nameColor),
+                        styledText(eventMessage, Color.WHITE),
+                        newline()
+                );
+            } else {
+                textFlow.getChildren().add(styledText(rowNumberPad + " ", Color.DIMGRAY));
+                appendHighlightedLine(textFlow, event, offenderName, reporterName);
+                textFlow.getChildren().add(newline());
+            }
         }
+    }
+
+    private static String bracketedTime(String timestamp) {
+        return "[" + timestamp + "]";
     }
 
     // -------------------------------------------------------------------------
@@ -2688,7 +2823,9 @@ public class ModerationReportController implements Controller<Region> {
     public void refreshReportPlayerRoleButtonText() {
         if (currentlySelectedItemNotNull == null) {
             copyReporterIdButton.setText(formatPlayerRoleButtonText("Reporter", "Reporter n/a"));
+            styleReportAccountButton(copyReporterIdButton, "Reporter");
             copyReportedUserIdButton.setText(formatPlayerRoleButtonText("Offender", "Reported User n/a"));
+            styleReportAccountButton(copyReportedUserIdButton, "Offender");
             return;
         }
 
@@ -2696,15 +2833,22 @@ public class ModerationReportController implements Controller<Region> {
                 ? "Reporter n/a"
                 : currentlySelectedItemNotNull.getReporter().getRepresentation();
         copyReporterIdButton.setText(formatPlayerRoleButtonText("Reporter", reporterRepresentation));
+        styleReportAccountButton(copyReporterIdButton, "Reporter");
 
         Collection<PlayerFX> reportedUsers = currentlySelectedItemNotNull.getReportedUsers();
         if (reportedUsers == null || reportedUsers.isEmpty()) {
             copyReportedUserIdButton.setText(formatPlayerRoleButtonText("Offender", "Reported User n/a"));
+            styleReportAccountButton(copyReportedUserIdButton, "Offender");
         } else {
             for (PlayerFX offender : reportedUsers) {
                 copyReportedUserIdButton.setText(formatPlayerRoleButtonText("Offender", offender.getRepresentation()));
+                styleReportAccountButton(copyReportedUserIdButton, "Offender");
             }
         }
+    }
+
+    private void styleReportAccountButton(Button button, String role) {
+        button.setStyle(getReportAccountRoleTextStyle(role));
     }
 
     private String formatPlayerRoleButtonText(String role, String playerText) {

--- a/src/main/resources/ui/main_window/report.fxml
+++ b/src/main/resources/ui/main_window/report.fxml
@@ -79,12 +79,16 @@
             </ScrollPane>
         </Tab>
         <Tab text="Reported Accounts">
-            <TableView fx:id="reportedPlayerTableView" maxHeight="Infinity"
-                       maxWidth="Infinity"/>
+            <VBox spacing="6" style="-fx-padding: 6 6 0 6;">
+                <CheckBox fx:id="autoSearchReportedAccountInUserManagementCheckBox" mnemonicParsing="false"
+                          text="Auto-search in User Management when selecting a user from the table below"/>
+                <TableView fx:id="reportedPlayerTableView" maxHeight="Infinity"
+                           maxWidth="Infinity" VBox.vgrow="ALWAYS"/>
+            </VBox>
         </Tab>
         <Tab text="Moderator Events">
             <ScrollPane prefHeight="200.0" prefWidth="200.0">
-                <TextFlow fx:id="moderatorEventTextFlow" prefHeight="200.0" prefWidth="200.0"/>
+                <TextFlow fx:id="moderatorEventTextFlow" />
             </ScrollPane>
         </Tab>
         <Tab text="Map Drawings">


### PR DESCRIPTION
## Changelog

### Reports
- Aligned Moderator Events rendering with Chat Log styling: row numbers, bracketed timestamps, fixed-width columns, and clearer reporter/offender colouring.
- Added account ban history support in the Reports UI.

### User Management
- Fix: Stale values from previous searches are no longer shown while new checks are loading.

## Commits

- [45d7895](https://github.com/magge-faf/faf-moderator-client-develop-modified/commit/45d7895fab34a36c4e465cf4c6e718ff64d4f9ec) fix(users): clear stale results before bulk checks
- [b77634b](https://github.com/magge-faf/faf-moderator-client-develop-modified/commit/b77634b1a80c17b0ce50da6be3af59e41b5bf0cb) feat(reports): improve report account tooling
- [9580089](https://github.com/magge-faf/faf-moderator-client-develop-modified/commit/958008932bc582c783a6e728223aa9ec60cecbf3) fix(avatars): avoid deprecated assignment flag

Commits viewable in [compare view](https://github.com/magge-faf/faf-moderator-client-develop-modified/compare/release...nightly).